### PR TITLE
getValidQuestions() excludes the section heading div

### DIFF
--- a/src/filler/engines/doc-extractor-engine.js
+++ b/src/filler/engines/doc-extractor-engine.js
@@ -9,23 +9,22 @@ export class DocExtractorEngine {
     };
   }
 
-  // will return true if the node is a typical google form section name and heading node
   checkSectionHeading(divNode) {
-    // returns if the div selected by div[role=listitem] is a heading or not
+     // Input Type: DOM Object
+    // Checks if the node is a typical google form section or not. name and heading node
+    // Tweak : - If the first childnode of the selected div has role=heading then it is a suspected section heading
+    // Return Type: Boolean
 
-    // logic : if the first childnode of the selected div has role=heading then it is a section heading
-    // list the attributes
+    // List the attributes
     const attributes = divNode.firstChild.attributes;
 
-    // might Throw TypeError in case the node is a simple div with no attributes.getNamedItem() function, thus calling null() function will throw typeerror
+    // Might throw TypeError in case the node is a simple div with no attributes.getNamedItem() function, thus calling null() function will throw typeerror
     try {
-      // if it turns out to be heading, then return true
-      if (attributes.getNamedItem("role").nodeValue === "heading") {
-        return true;
-      }
-      return false;
+      // If it turns out to be heading, then return true
+      return attributes.getNamedItem("role").nodeValue === "heading";
+
     } catch (typeError) {
-      // in case of typeError, we conclude it cant be heading thus return false 👍
+      // In case of typeError, we conclude it cant be heading thus return false
       // console.log(typeError);
       return false;
     }

--- a/src/filler/engines/doc-extractor-engine.js
+++ b/src/filler/engines/doc-extractor-engine.js
@@ -57,7 +57,7 @@ export class DocExtractorEngine {
     // clears the node from questions array if role=listitem includes the section heading (the purple colored one)
     questions = Array.from(
       document.querySelectorAll("div[role=listitem]")
-    ).filter((question) => !this.checkSectionHeading(question));
+      ).filter((question) => !this.checkSectionHeading(question));
     // -------------------------------------------------------
 
     return Array.prototype.slice.call(questions).filter((question) => {

--- a/src/filler/engines/doc-extractor-engine.js
+++ b/src/filler/engines/doc-extractor-engine.js
@@ -9,6 +9,24 @@ export class DocExtractorEngine {
     };
   }
 
+  // will return true if the node is a typical google form section name and heading node
+  checkSectionHeading(divNode) {
+    // returns if the div selected by div[role=listitem] is a heading or not
+    // logic : if the first childnode of the selected div has role=heading then it is a section heading
+    const attributes = divNode.firstChild.attributes;
+
+    try {
+      if (attributes.getNamedItem === null) return false;
+      else if (attributes.getNamedItem("role").nodeValue === "heading") {
+        return true;
+      }
+      return false;
+    } catch (typeError) {
+      // console.log(typeError);
+      return false;
+    }
+  }
+
   getValidQuestions() {
     // Returns an Array of DOM objects of validated Boxes present in Google Form
     // Return Type : Array
@@ -22,6 +40,7 @@ export class DocExtractorEngine {
     // But, as a garbage returns checkbox too
     // Returns a node list array, where each element is a DOM containing complete information for questions
     // Return Type : NodeList
+
     return document.querySelectorAll("div[role=listitem]");
   }
 
@@ -30,6 +49,14 @@ export class DocExtractorEngine {
     // Weeds out Checkbox collected as a false positive in getQuestions method
     // and returns only the correct ones
     // Return Type : Array
+
+    // ---------- validate if section heading or not ---------
+    // clears the node from questions array if role=listitem includes the section heading (the purple colored one)
+    questions = Array.from(
+      document.querySelectorAll("div[role=listitem]")
+    ).filter((question) => !this.checkSectionHeading(question));
+    // -------------------------------------------------------
+
     return Array.prototype.slice.call(questions).filter((question) => {
       return !this.isCheckBoxListItem(question);
     });

--- a/src/filler/engines/doc-extractor-engine.js
+++ b/src/filler/engines/doc-extractor-engine.js
@@ -12,12 +12,15 @@ export class DocExtractorEngine {
   // will return true if the node is a typical google form section name and heading node
   checkSectionHeading(divNode) {
     // returns if the div selected by div[role=listitem] is a heading or not
+
     // logic : if the first childnode of the selected div has role=heading then it is a section heading
+    // list the attributes
     const attributes = divNode.firstChild.attributes;
 
+    //
     try {
-      if (attributes.getNamedItem === null) return false;
-      else if (attributes.getNamedItem("role").nodeValue === "heading") {
+      // if it turns out to be heading, then return true
+      if (attributes.getNamedItem("role").nodeValue === "heading") {
         return true;
       }
       return false;

--- a/src/filler/engines/doc-extractor-engine.js
+++ b/src/filler/engines/doc-extractor-engine.js
@@ -12,16 +12,20 @@ export class DocExtractorEngine {
   // will return true if the node is a typical google form section name and heading node
   checkSectionHeading(divNode) {
     // returns if the div selected by div[role=listitem] is a heading or not
+
     // logic : if the first childnode of the selected div has role=heading then it is a section heading
+    // list the attributes
     const attributes = divNode.firstChild.attributes;
 
+    // might Throw TypeError in case the node is a simple div with no attributes.getNamedItem() function, thus calling null() function will throw typeerror
     try {
-      if (attributes.getNamedItem === null) return false;
-      else if (attributes.getNamedItem("role").nodeValue === "heading") {
+      // if it turns out to be heading, then return true
+      if (attributes.getNamedItem("role").nodeValue === "heading") {
         return true;
       }
       return false;
     } catch (typeError) {
+      // in case of typeError, we conclude it cant be heading thus return false 👍
       // console.log(typeError);
       return false;
     }


### PR DESCRIPTION
The following is the correction : -

pic-1 Even the section heading is selected as a valid question
![Screenshot_20230719_142025](https://github.com/rootCircle/symmetrical-octo-spork/assets/11803841/0982bc6b-0e72-48d3-8a03-e0eb0256479b)

---
#### after correction
pic-2 the section heading is excluded
![Screenshot_20230719_142202](https://github.com/rootCircle/symmetrical-octo-spork/assets/11803841/d703a9d9-b289-4c59-97fe-ca56d646585e)
