### PR TITLE
refactored fields-extractor-engine code

### DIFF
--- a/src/filler/engines/fields-extractor-engine.js
+++ b/src/filler/engines/fields-extractor-engine.js
@@ -5,89 +5,580 @@ export class FieldsExtractorEngine {
   // It might also extract the options in case of MCQs or other types, where answers do
   // play a  critical role
 
-  constructor() { }
+  constructor() {}
 
   getFields(element, fieldType) {
-
     let fields = {
-      "title": this.getTitle(element),
-      "description": this.getDescription(element)
+      title: this.getTitle(element),
+      description: this.getDescription(element),
     };
 
     // Dynamic values like options can be appended based on field type
     // Get options based on the field type and append them to the 'fields' object
 
+    // this sets the required fields itself, the conditional checking is done in the function itself
+    // the function is is highly abstracted
 
-    // Extracting the options if the field type is MultiCorrect
-    if (fieldType === QType.MULTI_CORRECT) {
-      //Handles `MultiCorrect`
-      //We get Options in an array
-      fields.options = this.getOptions_MULTI_CORRECT(element);
-    }
+    // TODO : the getOptions() can be broken down into furthur functions if needed, just ensure that the return type is consistent so that the below line still works
+    let optionFields = this.getOptions(fieldType, element);
+    fields = { ...fields, ...optionFields };
 
+    // -----------------------------------------------
+    // > AUTHOR: DC CODE REFACTORING AND MODIFICATION, THE CODE BETWEEN ~~~~~~~~~~~ IS depricated, but still kept as comment since there can be some code copying issue as the code amount was quite huge.
+    // -----------------------------------------------
 
-    // Extracting the options if the field type is MultiCorrect_WITH_OTHER
-    else if (fieldType === QType.MULTI_CORRECT_WITH_OTHER) {
-      //Handles - `MultiCorrect With Other`.
-      // We get options in the form of an OBJECT which has two properties
-      //1. options - which contain options array
-      //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-      fields.options = this.getOptions_MULTI_CORRECT_WITH_OTHER(element).options;
-      fields.other = this.getOptions_MULTI_CORRECT_WITH_OTHER(element).other;
-    }
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // DEPRICATED CODE BELOW
+    /*
+  //   // Extracting the options if the field type is MultiCorrect
+  //   if (fieldType === QType.MULTI_CORRECT) {
+  //     //Handles `MultiCorrect`
+  //     //We get Options in an array
+  //     fields.options = this.getOptions_MULTI_CORRECT(element);
+  //   }
 
+  //   // Extracting the options if the field type is MultiCorrect_WITH_OTHER
+  //   else if (fieldType === QType.MULTI_CORRECT_WITH_OTHER) {
+  //     //Handles - `MultiCorrect With Other`.
+  //     // We get options in the form of an OBJECT which has two properties
+  //     //1. options - which contain options array
+  //     //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+  //     fields.options =
+  //       this.getOptions_MULTI_CORRECT_WITH_OTHER(element).options;
+  //     fields.other = this.getOptions_MULTI_CORRECT_WITH_OTHER(element).other;
+  //   }
 
-    // Extracting the options if the field type is Dropdown
-    else if (fieldType === QType.DROPDOWN) {
-      // We get options in the form of an array
-      fields.options = this.getOptions_Dropdown(element);
-    }
+  //   // Extracting the options if the field type is Dropdown
+  //   else if (fieldType === QType.DROPDOWN) {
+  //     // We get options in the form of an array
+  //     fields.options = this.getOptions_Dropdown(element);
+  //   }
 
+  //   // Extracting the options if the field type is 'Multiple Choice'
+  //   else if (fieldType === QType.MULTIPLE_CHOICE) {
+  //     // We get options in the form of an array
+  //     fields.options = this.getOptions_MULTIPLE_CHOICE(element);
+  //   }
 
-    // Extracting the options if the field type is 'Multiple Choice'
-    else if (fieldType === QType.MULTIPLE_CHOICE) {
-      // We get options in the form of an array
-      fields.options = this.getOptions_MULTIPLE_CHOICE(element);
+  //   // Extracting the options if the field type is 'Multiple Choice With Other'.
+  //   if (fieldType === QType.MULTIPLE_CHOICE_WITH_OTHER) {
+  //     // We get options in the form of an OBJECT which has two properties
+  //     //1. options - which contain options array
+  //     //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+  //     fields.options =
+  //       this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element).options;
+  //     fields.other = this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element).other;
+  //   }
 
-    }
+  //   // Extracting the options if the field type is 'Linear Scale'
+  //   if (fieldType === QType.LINEAR_SCALE) {
+  //     //We get options in an object {filteredOptions,filterLowerUpper}
+  //     //In Linear_Scale Left and Right Bounds are given and options are distributed uniformly between these bounds.
+  //     //These elements which we are saying Upper_bound and Lower_bound may be strings or characters.
 
+      
+  //     // Note
+  //     // We added one more attribute to fields `lowerUpperBounds` whose value will have an array containing LowerBound,UpperBound.
+  //     fields.options = this.getOptions_LINEAR_SCALE(element).filteredOptions;
+  //     fields.lowerUpperBounds =
+  //       this.getOptions_LINEAR_SCALE(element).filterLowerUpper;
+  //   }
 
-    // Extracting the options if the field type is 'Multiple Choice With Other'.
-    if (fieldType === QType.MULTIPLE_CHOICE_WITH_OTHER) {
-      // We get options in the form of an OBJECT which has two properties
-      //1. options - which contain options array
-      //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-      fields.options = this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element).options;
-      fields.other = this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element).other;
-    }
+  //   // Extracting the options if the field type is `Checkbox Grid` or `Multiple Choice Grid`
+  //   if (
+  //     fieldType === QType.CHECKBOX_GRID ||
+  //     fieldType === QType.MULTIPLE_CHOICE_GRID
+  //   ) {
+  //     //We get options in form of an object
+  //     //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
+  //     fields.options = this.getOptions_GRID(element);
+  //   }
+  //   //Returning the object fields.It contains title , description , options (if that question has) keys .
+  //   return fields;
+  // }
 
+  // // Testing on Different Forms required
+  // getTitle(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the title of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is obtained by selecting the first child element of div with role=heading
+  //   // Return Type : String
+  //   let required = element.querySelector('div[role="heading"]');
+  //   required = required.children[0];
 
-    // Extracting the options if the field type is 'Linear Scale'
-    if (fieldType === QType.LINEAR_SCALE) {
-      //We get options in an object {filteredOptions,filterLowerUpper}
-      //In Linear_Scale Left and Right Bounds are given and options are distributed uniformly between these bounds.
-      //These elements which we are saying Upper_bound and Lower_bound may be strings or characters.
+  //   let content = "";
 
-      /*
-      Note
-      We added one more attribute to fields `lowerUpperBounds` whose value will have an array containing LowerBound,UpperBound.
-      */
-      fields.options = this.getOptions_LINEAR_SCALE(element).filteredOptions;
-      fields.lowerUpperBounds = this.getOptions_LINEAR_SCALE(element).filterLowerUpper;
-    }
+  //   // Every new line is either inside a div or independent, hence has nodeName #text
+  //   Array.from(required.childNodes).forEach((element) => {
+  //     if (element.nodeName === "#text") {
+  //       content += element.textContent + "\n";
+  //     } else {
+  //       content += element.textContent + "\n";
+  //     }
+  //   });
 
+  //   // Remove trailing whitespace at the end
+  //   return content.trimEnd();
+  // }
 
-    // Extracting the options if the field type is `Checkbox Grid` or `Multiple Choice Grid`
-    if (fieldType === QType.CHECKBOX_GRID || fieldType === QType.MULTIPLE_CHOICE_GRID) {
-      //We get options in form of an object
-      //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
-      fields.options = this.getOptions_GRID(element);
-    }
-    //Returning the object fields.It contains title , description , options (if that question has) keys .
-    return fields;
+  // // Testing on Different Forms required
+  // getDescription(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the description of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is obtained by selecting the second child element of the parent element of div with role=heading
+  //   // Return Type : String (Returns null if no description is found!)
+  //   let required = element.querySelector('div[role="heading"]');
+  //   required = required.parentElement.children[1];
+  //   if (required === undefined || required.textContent === "") {
+  //     // console.log("There is no description for this box!");
+  //     return null;
+  //   }
+
+  //   let content = "";
+
+  //   // Every new line is either inside a div or independent, hence has nodeName #text
+  //   Array.from(required.childNodes).forEach((element) => {
+  //     if (element.nodeName === "#text") {
+  //       content += element.textContent + "\n";
+  //     } else {
+  //       content += element.textContent + "\n";
+  //     }
+  //   });
+  //   // console.log("checkpoint1");
+  //   // Remove trailing whitespace at the end
+  //   return content.trimEnd();
+  // }
+
+  // // Functions for Extracting Options
+  // //Extracting the options for field type = MultiCorrect With Other or MultiCorrect
+  // getOptions_MULTI_CORRECT(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the options of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+  //   // Return Type : Array (containing option's data) =>null if no options are present
+
+  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
+  //   if (!optionLabels || optionLabels.length === 0) {
+  //     // If no option labels are found, return an empty array
+  //     return [];
+  //   }
+
+  //   const options = [];
+  //   //we will go through all spans and extract its text content and store in our answer array.
+  //   optionLabels.forEach((label) => {
+  //     options.push(label.textContent.trim());
+  //   });
+
+  //   return options;
+  // }
+
+  // getOptions_MULTI_CORRECT_WITH_OTHER(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the options of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+  //   // Return Type : OBJECT which has two properties
+  //   //1. options - which contain options array
+  //   //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+  //   //it will contain an input field and in case no option match , we need to write our answer there
+
+  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
+  //   if (!optionLabels || optionLabels.length === 0) {
+  //     // If no option labels are found, return an empty array
+  //     return [];
+  //   }
+
+  //   const options = [];
+  //   //we will go through all spans and extract its text content and store in our answer array.
+  //   optionLabels.forEach((label) => {
+  //     options.push(label.textContent.trim());
+  //   });
+  //   // Remove the last option and add 'Other' field in the object
+  //   const lastOptionIndex = options.length - 1;
+  //   const otherOption = options.splice(lastOptionIndex, 1)[0];
+
+  //   return { options, other: otherOption };
+  // }
+
+  // //Extracting the options for field type = MultipleChoice With Other or MultipleChoice
+  // getOptions_MULTIPLE_CHOICE(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the options of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+  //   // Return Type : Array (containing option's data) =>null if no options are present
+
+  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
+  //   if (!optionLabels || optionLabels.length === 0) {
+  //     // If no option labels are found, return an empty array
+  //     return [];
+  //   }
+
+  //   const options = [];
+  //   //we will go through all spans and extract its text content and store in our answer array.
+  //   optionLabels.forEach((label) => {
+  //     options.push(label.textContent.trim());
+  //   });
+
+  //   return options;
+  // }
+
+  // getOptions_MULTIPLE_CHOICE_WITH_OTHER(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the options of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+  //   // Return Type : OBJECT which has two properties
+  //   //1. options - which contain options array
+  //   //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+  //   //it will contain an input field and in case no option match , we need to write our answer there
+
+  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
+  //   if (!optionLabels || optionLabels.length === 0) {
+  //     // If no option labels are found, return an empty array
+  //     return [];
+  //   }
+
+  //   const options = [];
+  //   //we will go through all spans and extract its text content and store in our answer array.
+  //   optionLabels.forEach((label) => {
+  //     options.push(label.textContent.trim());
+  //   });
+
+  //   // Remove the last option and add 'Other' field in the object
+  //   const lastOptionIndex = options.length - 1;
+  //   const otherOption = options.splice(lastOptionIndex, 1)[0];
+
+  //   return { options, other: otherOption };
+  // }
+
+  // //Extracting the options for field type = LinearScale
+  // getOptions_LINEAR_SCALE(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the options of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node for Lower and Upper bound is obtained by selecting the span whose role="presentation" and then need to traverse more
+  //   //since no attribute can be found which can help
+  //   //         -Option are present in in divs inside elements which has dir="auto".
+  //   // Return Type : Object containing two arrays - {filterLowerUpper,filteredOptions}
+  //   //filterLowerUpper- ArraySize=2 , contain lowerBound , upperBound
+  //   //filteredOptions- It will contain options.
+
+  //   const elementsWithHierarchy = element
+  //     .querySelector('span[role="presentation"]')
+  //     .querySelectorAll("div > div:last-child > div:last-child");
+  //   let lowerBound = null;
+  //   let upperBound = null;
+  //   //In elementWithHierarchy many nodes are present but we are sure 1st node is Lower bound and last node is Upper bound.
+  //   elementsWithHierarchy.forEach((el) => {
+  //     const textContent = el.textContent.trim();
+  //     if (lowerBound === null && textContent !== "") {
+  //       lowerBound = textContent; //Assigning lowerBound with 1st node
+  //     } else if (lowerBound !== null && textContent !== "") {
+  //       upperBound = textContent; //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound.
+  //     }
+  //   });
+
+  //   //Storing options in `options` array.
+  //   const optionElements = element.querySelectorAll('div[dir="auto"]');
+  //   const options = Array.from(optionElements).map((optionElement) =>
+  //     optionElement.textContent.trim()
+  //   );
+
+  //   // Storing LowerBound and UpperBound data
+  //   // lowerUpperBound array - the lower bound at the beginning (0th index) , and the upper bound at the end (1st index)
+  //   const lowerUpperBound = [lowerBound, upperBound];
+
+  //   // Filter out any null or empty string elements from the array
+  //   //This was creating an unexpected problem!
+  //   const filteredOptions = options.filter(
+  //     (item) => item !== null && item !== ""
+  //   );
+  //   const filterLowerUpper = lowerUpperBound.filter(
+  //     (item) => item !== null && item !== ""
+  //   );
+
+  //   return { filterLowerUpper, filteredOptions };
+  // }
+
+  // //Extracting the options for field type = Multiple Choice Grid or Checkbox Grid.
+  // getOptions_GRID(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the options of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is founded by Brute-force traversing no attribute can be found to be helpful.
+  //   //
+  //   // Return Type : Object containing 2 array
+  //   //              - 1st array will denote contents of row1,row2,row3...
+  //   //              -2nd array will denote contents of column1,column2,column3
+
+  //   //No property can be found so need to traverse this way only!
+  //   const path =
+  //     "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
+
+  //   //After getting to this path,
+  //   //its first child contains a div which contains all columns.
+  //   // and rest divs were for rows
+  //   //But between each row there was an empty div so we need to extract 2nd,4th,6th.. i.e even numbered divs**
+  //   const rows = element.querySelectorAll(`${path}:nth-child(2n)`);
+  //   const columns = element.querySelectorAll(`${path}:first-child > div`);
+
+  //   const gridArray = [];
+  //   //In these columns if we think in term of matrix then (0,0) place is left vacant so we sliced form 1 and take out content of each column.
+  //   const columnsArray = Array.from(columns)
+  //     .slice(1)
+  //     .map((column) => column.textContent.trim());
+  //   const rowsArray = Array.from(rows).map((row) => row.textContent.trim());
+
+  //   //Returning an Object containing 2 array
+  //   //      - 1st array will denote contents of row1,row2,row3...
+  //   //      -2nd array will denote contents of column1,column2,column3
+  //   return {
+  //     rows: rowsArray,
+  //     columns: columnsArray,
+  //   };
+  // }
+
+  // //Extracting the options for field type = Dropdown.
+  // getOptions_Dropdown(element) {
+  //   // Input Type: DOM Object
+  //   // Extracts the options of the question
+  //   // Tweak : - The extraction is based on the DOM tree
+  //   //         - The required node is found by selecting all divs having role="option" , inside this there are spans which contain options.
+  //   // Return Type : Array containing options.
+
+  //   const optionDivs = element.querySelectorAll('div[role="option"]');
+
+  //   if (!optionDivs || optionDivs.length === 0) {
+  //     return [];
+  //   }
+
+  //   const optionTexts = Array.from(optionDivs).map((div) => {
+  //     const span = div.querySelector("span");
+  //     if (span) {
+  //       return span.textContent.trim();
+  //     } else {
+  //       return null;
+  //     }
+  //   });
+
+  //   //All options were extracted but 1st element was `choose` so removed that.
+  //   // Remove the first element ("Choose" option) from the array
+  //   const optionsWithoutChoose = optionTexts.slice(1);
+  //   return optionsWithoutChoose;
+    // }
+    
+    */
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   }
 
+  // Function for Extracting Options
+  // Input Type: DOM Object
+  // Extracts the options of the question
+  // ! Return Type : An object containing the options field and its required value
+  // ! the return object may contain field other than options, as returned by the corresponding QuestionType
+  getOptions(questionType, element) {
+    let optionLabels = null;
+    let options = [];
 
+    switch (questionType) {
+      // Tweak : - The extraction is based on the DOM tree
+      //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+      // Return Type : object with options field containing an Array (containing option's data) =>null if no options are present
+      case QType.MULTI_CORRECT:
+        optionLabels = element.querySelectorAll('span[dir="auto"]');
+        if (!optionLabels || optionLabels.length === 0) {
+          // If no option labels are found, return an empty array
+          return { options: [] };
+        }
+
+        options = [];
+        //we will go through all spans and extract its text content and store in our answer array.
+        optionLabels.forEach((label) => {
+          options.push(label.textContent.trim());
+        });
+
+        return { options: options };
+        break;
+
+      // Tweak : - The extraction is based on the DOM tree
+      //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+      // Return Type : OBJECT which has two properties
+      //1. options - which contain options array
+      //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+      //it will contain an input field and in case no option match , we need to write our answer there
+      case QType.MULTI_CORRECT_WITH_OTHER:
+        optionLabels = element.querySelectorAll('span[dir="auto"]');
+        if (!optionLabels || optionLabels.length === 0) {
+          // If no option labels are found, return an empty array
+          return { options: [] };
+        }
+
+        options = [];
+        //we will go through all spans and extract its text content and store in our answer array.
+        optionLabels.forEach((label) => {
+          options.push(label.textContent.trim());
+        });
+        // Remove the last option and add 'Other' field in the object
+        let lastOptionIndex = options.length - 1;
+        let otherOption = options.splice(lastOptionIndex, 1)[0];
+
+        return { options: options, other: otherOption };
+        break;
+
+      // Tweak : - The extraction is based on the DOM tree
+      //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+      // Return Type : object with options field in the following format { options: Array (containing option's data) =>null if no options are present }
+      case QType.MULTIPLE_CHOICE:
+        optionLabels = element.querySelectorAll('span[dir="auto"]');
+        if (!optionLabels || optionLabels.length === 0) {
+          // If no option labels are found, return an empty array
+          return { options: [] };
+        }
+
+        options = [];
+        //we will go through all spans and extract its text content and store in our answer array.
+        optionLabels.forEach((label) => {
+          options.push(label.textContent.trim());
+        });
+
+        return { options: options };
+        break;
+
+      // Return Type : OBJECT which has two properties
+      // 1. options - which contain options array
+      // 2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+      // it will contain an input field and in case no option match , we need to write our answer there
+      case QType.MULTIPLE_CHOICE_WITH_OTHER:
+        optionLabels = element.querySelectorAll('span[dir="auto"]');
+        if (!optionLabels || optionLabels.length === 0) {
+          // If no option labels are found, return an empty array
+          return { options: [] };
+        }
+
+        options = [];
+        //we will go through all spans and extract its text content and store in our answer array.
+        optionLabels.forEach((label) => {
+          options.push(label.textContent.trim());
+        });
+
+        // Remove the last option and add 'Other' field in the object
+        lastOptionIndex = options.length - 1;
+        otherOption = options.splice(lastOptionIndex, 1)[0];
+
+        return { options: options, other: otherOption };
+        break;
+
+      // Tweak : - The extraction is based on the DOM tree
+      //         - The required node for Lower and Upper bound is obtained by selecting the span whose role="presentation" and then need to traverse more
+      // since no attribute can be found which can help
+      //         -Option are present in in divs inside elements which has dir="auto".
+      // Return Type : Object containing two arrays - {filterLowerUpper,filteredOptions}
+      // filterLowerUpper- ArraySize=2 , contain lowerBound , upperBound
+      // filteredOptions- It will contain options.
+      case QType.LINEAR_SCALE:
+        let elementsWithHierarchy = element
+          .querySelector('span[role="presentation"]')
+          .querySelectorAll("div > div:last-child > div:last-child");
+        let lowerBound = null;
+        let upperBound = null;
+        //In elementWithHierarchy many nodes are present but we are sure 1st node is Lower bound and last node is Upper bound.
+        elementsWithHierarchy.forEach((el) => {
+          let textContent = el.textContent.trim();
+          if (lowerBound === null && textContent !== "") {
+            lowerBound = textContent; //Assigning lowerBound with 1st node
+          } else if (lowerBound !== null && textContent !== "") {
+            upperBound = textContent; //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound.
+          }
+        });
+
+        //Storing options in `options` array.
+        let optionElements = element.querySelectorAll('div[dir="auto"]');
+        options = Array.from(optionElements).map((optionElement) =>
+          optionElement.textContent.trim()
+        );
+
+        // Storing LowerBound and UpperBound data
+        // lowerUpperBound array - the lower bound at the beginning (0th index) , and the upper bound at the end (1st index)
+        let lowerUpperBound = [lowerBound, upperBound];
+
+        // Filter out any null or empty string elements from the array
+        //This was creating an unexpected problem!
+        const filteredOptions = options.filter(
+          (item) => item !== null && item !== ""
+        );
+        const filterLowerUpper = lowerUpperBound.filter(
+          (item) => item !== null && item !== ""
+        );
+
+        return { lowerUpperBounds: filterLowerUpper, options: filteredOptions };
+        break;
+
+      // Tweak : - The extraction is based on the DOM tree
+      //         - The required node is founded by Brute-force traversing no attribute can be found to be helpful.
+      //
+      // Return Type : Object containing 2 array
+      //              - 1st array will denote contents of row1,row2,row3...
+      //              -2nd array will denote contents of column1,column2,column3
+      case QType.CHECKBOX_GRID:
+      case QType.MULTIPLE_CHOICE_GRID:
+        //No property can be found so need to traverse this way only!
+        let path =
+          "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
+
+        //After getting to this path,
+        //its first child contains a div which contains all columns.
+        // and rest divs were for rows
+        //But between each row there was an empty div so we need to extract 2nd,4th,6th.. i.e even numbered divs**
+        const rows = element.querySelectorAll(`${path}:nth-child(2n)`);
+        const columns = element.querySelectorAll(`${path}:first-child > div`);
+
+        const gridArray = [];
+        //In these columns if we think in term of matrix then (0,0) place is left vacant so we sliced form 1 and take out content of each column.
+        const columnsArray = Array.from(columns)
+          .slice(1)
+          .map((column) => column.textContent.trim());
+        const rowsArray = Array.from(rows).map((row) => row.textContent.trim());
+
+        //Returning an Object containing 2 array
+        //      - 1st array will denote contents of row1,row2,row3...
+        //      -2nd array will denote contents of column1,column2,column3
+        return {
+          options: {
+            rows: rowsArray,
+            columns: columnsArray,
+          },
+        };
+        break;
+
+      // Tweak : - The extraction is based on the DOM tree
+      //         - The required node is found by selecting all divs having role="option" , inside this there are spans which contain options.
+      // Return Type : Object with options field value is an Array containing the required options.
+      case QType.DROPDOWN:
+        const optionDivs = element.querySelectorAll('div[role="option"]');
+        if (!optionDivs || optionDivs.length === 0) {
+          return [];
+        }
+
+        const optionTexts = Array.from(optionDivs).map((div) => {
+          const span = div.querySelector("span");
+          if (span) {
+            return span.textContent.trim();
+          } else {
+            return null;
+          }
+        });
+
+        //All options were extracted but 1st element was `choose` so removed that.
+        // Remove the first element ("Choose" option) from the array
+        const optionsWithoutChoose = optionTexts.slice(1);
+        return { options: optionsWithoutChoose };
+        break;
+    }
+  }
 
   // Testing on Different Forms required
   getTitle(element) {
@@ -102,11 +593,10 @@ export class FieldsExtractorEngine {
     let content = "";
 
     // Every new line is either inside a div or independent, hence has nodeName #text
-    Array.from(required.childNodes).forEach(element => {
-      if (element.nodeName === '#text') {
+    Array.from(required.childNodes).forEach((element) => {
+      if (element.nodeName === "#text") {
         content += element.textContent + "\n";
-      }
-      else {
+      } else {
         content += element.textContent + "\n";
       }
     });
@@ -114,8 +604,6 @@ export class FieldsExtractorEngine {
     // Remove trailing whitespace at the end
     return content.trimEnd();
   }
-
-
 
   // Testing on Different Forms required
   getDescription(element) {
@@ -134,245 +622,15 @@ export class FieldsExtractorEngine {
     let content = "";
 
     // Every new line is either inside a div or independent, hence has nodeName #text
-    Array.from(required.childNodes).forEach(element => {
-      if (element.nodeName === '#text') {
+    Array.from(required.childNodes).forEach((element) => {
+      if (element.nodeName === "#text") {
         content += element.textContent + "\n";
-      }
-      else {
+      } else {
         content += element.textContent + "\n";
       }
     });
     // console.log("checkpoint1");
     // Remove trailing whitespace at the end
     return content.trimEnd();
-  }
-
-
-
-
-  // Functions for Extracting Options
-  //Extracting the options for field type = MultiCorrect With Other or MultiCorrect
-  getOptions_MULTI_CORRECT(element) {
-    // Input Type: DOM Object
-    // Extracts the options of the question
-    // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-    // Return Type : Array (containing option's data) =>null if no options are present
-
-    const optionLabels = element.querySelectorAll('span[dir="auto"]');
-    if (!optionLabels || optionLabels.length === 0) {
-      // If no option labels are found, return an empty array
-      return [];
-    }
-
-    const options = [];
-    //we will go through all spans and extract its text content and store in our answer array.
-    optionLabels.forEach((label) => {
-      options.push(label.textContent.trim());
-    });
-
-    return options;
-  }
-
-
-  getOptions_MULTI_CORRECT_WITH_OTHER(element) {
-    // Input Type: DOM Object
-    // Extracts the options of the question
-    // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-    // Return Type : OBJECT which has two properties
-    //1. options - which contain options array
-    //2. other - which contain `other:` which need to deal in separate way to ask Chatbot 
-    //it will contain an input field and in case no option match , we need to write our answer there
-
-    const optionLabels = element.querySelectorAll('span[dir="auto"]');
-    if (!optionLabels || optionLabels.length === 0) {
-      // If no option labels are found, return an empty array
-      return [];
-    }
-
-    const options = [];
-    //we will go through all spans and extract its text content and store in our answer array.
-    optionLabels.forEach((label) => {
-      options.push(label.textContent.trim());
-    });
-    // Remove the last option and add 'Other' field in the object
-    const lastOptionIndex = options.length - 1;
-    const otherOption = options.splice(lastOptionIndex, 1)[0];
-
-    return { options, other: otherOption };
-
-  }
-
-
-  //Extracting the options for field type = MultipleChoice With Other or MultipleChoice
-  getOptions_MULTIPLE_CHOICE(element) {
-    // Input Type: DOM Object
-    // Extracts the options of the question
-    // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-    // Return Type : Array (containing option's data) =>null if no options are present
-
-    const optionLabels = element.querySelectorAll('span[dir="auto"]');
-    if (!optionLabels || optionLabels.length === 0) {
-      // If no option labels are found, return an empty array
-      return [];
-    }
-
-    const options = [];
-    //we will go through all spans and extract its text content and store in our answer array.
-    optionLabels.forEach((label) => {
-      options.push(label.textContent.trim());
-    });
-
-
-
-    return options;
-  }
-
-
-  getOptions_MULTIPLE_CHOICE_WITH_OTHER(element) {
-    // Input Type: DOM Object
-    // Extracts the options of the question
-    // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-    // Return Type : OBJECT which has two properties
-    //1. options - which contain options array
-    //2. other - which contain `other:` which need to deal in separate way to ask Chatbot 
-    //it will contain an input field and in case no option match , we need to write our answer there
-
-    const optionLabels = element.querySelectorAll('span[dir="auto"]');
-    if (!optionLabels || optionLabels.length === 0) {
-      // If no option labels are found, return an empty array
-      return [];
-    }
-
-    const options = [];
-    //we will go through all spans and extract its text content and store in our answer array.
-    optionLabels.forEach((label) => {
-      options.push(label.textContent.trim());
-    });
-
-
-    // Remove the last option and add 'Other' field in the object
-    const lastOptionIndex = options.length - 1;
-    const otherOption = options.splice(lastOptionIndex, 1)[0];
-
-    return { options, other: otherOption };
-
-  }
-
-
-  //Extracting the options for field type = LinearScale
-  getOptions_LINEAR_SCALE(element) {
-    // Input Type: DOM Object
-    // Extracts the options of the question
-    // Tweak : - The extraction is based on the DOM tree
-    //         - The required node for Lower and Upper bound is obtained by selecting the span whose role="presentation" and then need to traverse more 
-    //since no attribute can be found which can help
-    //         -Option are present in in divs inside elements which has dir="auto".
-    // Return Type : Object containing two arrays - {filterLowerUpper,filteredOptions}
-    //filterLowerUpper- ArraySize=2 , contain lowerBound , upperBound
-    //filteredOptions- It will contain options.
-
-    const elementsWithHierarchy = element.querySelector('span[role="presentation"]').querySelectorAll('div > div:last-child > div:last-child');
-    let lowerBound = null;
-    let upperBound = null;
-    //In elementWithHierarchy many nodes are present but we are sure 1st node is Lower bound and last node is Upper bound.
-    elementsWithHierarchy.forEach((el) => {
-      const textContent = el.textContent.trim();
-      if (lowerBound === null && textContent !== '') {
-        lowerBound = textContent;             //Assigning lowerBound with 1st node
-      }
-
-      else if (lowerBound !== null && textContent !== '') {
-        upperBound = textContent;             //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound. 
-      }
-
-    });
-
-    //Storing options in `options` array.
-    const optionElements = element.querySelectorAll('div[dir="auto"]');
-    const options = Array.from(optionElements).map((optionElement) => optionElement.textContent.trim());
-
-    // Storing LowerBound and UpperBound data
-    // lowerUpperBound array - the lower bound at the beginning (0th index) , and the upper bound at the end (1st index)
-    const lowerUpperBound = [lowerBound, upperBound];
-
-    // Filter out any null or empty string elements from the array
-    //This was creating an unexpected problem!
-    const filteredOptions = options.filter(item => item !== null && item !== '');
-    const filterLowerUpper = lowerUpperBound.filter(item => item !== null && item !== '');
-
-    return { filterLowerUpper, filteredOptions };
-  }
-
-
-  //Extracting the options for field type = Multiple Choice Grid or Checkbox Grid.
-  getOptions_GRID(element) {
-    // Input Type: DOM Object
-    // Extracts the options of the question
-    // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is founded by Brute-force traversing no attribute can be found to be helpful.
-    //         
-    // Return Type : Object containing 2 array 
-    //              - 1st array will denote contents of row1,row2,row3...
-    //              -2nd array will denote contents of column1,column2,column3
-
-
-    //No property can be found so need to traverse this way only!
-    const path = "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
-
-
-    //After getting to this path,
-    //its first child contains a div which contains all columns.
-    // and rest divs were for rows
-    //But between each row there was an empty div so we need to extract 2nd,4th,6th.. i.e even numbered divs**
-    const rows = element.querySelectorAll(`${path}:nth-child(2n)`);
-    const columns = element.querySelectorAll(`${path}:first-child > div`);
-
-    const gridArray = [];
-    //In these columns if we think in term of matrix then (0,0) place is left vacant so we sliced form 1 and take out content of each column.
-    const columnsArray = Array.from(columns).slice(1).map((column) => column.textContent.trim());
-    const rowsArray = Array.from(rows).map((row) => row.textContent.trim());
-
-    //Returning an Object containing 2 array 
-    //      - 1st array will denote contents of row1,row2,row3...
-    //      -2nd array will denote contents of column1,column2,column3
-    return {
-      rows: rowsArray,
-      columns: columnsArray,
-    };
-  }
-
-
-
-  //Extracting the options for field type = Dropdown.
-  getOptions_Dropdown(element) {
-    // Input Type: DOM Object
-    // Extracts the options of the question
-    // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is found by selecting all divs having role="option" , inside this there are spans which contain options.
-    // Return Type : Array containing options.
-
-    const optionDivs = element.querySelectorAll('div[role="option"]');
-
-    if (!optionDivs || optionDivs.length === 0) {
-      return [];
-    }
-
-    const optionTexts = Array.from(optionDivs).map((div) => {
-      const span = div.querySelector("span");
-      if (span) {
-        return span.textContent.trim();
-      } else {
-        return null;
-      }
-    });
-
-    //All options were extracted but 1st element was `choose` so removed that.
-    // Remove the first element ("Choose" option) from the array
-    const optionsWithoutChoose = optionTexts.slice(1);
-    return optionsWithoutChoose;
   }
 }

--- a/src/filler/engines/fields-extractor-engine.js
+++ b/src/filler/engines/fields-extractor-engine.js
@@ -5,7 +5,7 @@ export class FieldsExtractorEngine {
   // It might also extract the options in case of MCQs or other types, where answers do
   // play a  critical role
 
-  constructor() {}
+  constructor() { }
 
   getFields(element, fieldType) {
     let fields = {
@@ -23,560 +23,71 @@ export class FieldsExtractorEngine {
     let optionFields = this.getOptions(fieldType, element);
     fields = { ...fields, ...optionFields };
 
-    // -----------------------------------------------
-    // > AUTHOR: DC CODE REFACTORING AND MODIFICATION, THE CODE BETWEEN ~~~~~~~~~~~ IS depricated, but still kept as comment since there can be some code copying issue as the code amount was quite huge.
-    // -----------------------------------------------
-
-    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // DEPRICATED CODE BELOW
-    /*
-  //   // Extracting the options if the field type is MultiCorrect
-  //   if (fieldType === QType.MULTI_CORRECT) {
-  //     //Handles `MultiCorrect`
-  //     //We get Options in an array
-  //     fields.options = this.getOptions_MULTI_CORRECT(element);
-  //   }
-
-  //   // Extracting the options if the field type is MultiCorrect_WITH_OTHER
-  //   else if (fieldType === QType.MULTI_CORRECT_WITH_OTHER) {
-  //     //Handles - `MultiCorrect With Other`.
-  //     // We get options in the form of an OBJECT which has two properties
-  //     //1. options - which contain options array
-  //     //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-  //     fields.options =
-  //       this.getOptions_MULTI_CORRECT_WITH_OTHER(element).options;
-  //     fields.other = this.getOptions_MULTI_CORRECT_WITH_OTHER(element).other;
-  //   }
-
-  //   // Extracting the options if the field type is Dropdown
-  //   else if (fieldType === QType.DROPDOWN) {
-  //     // We get options in the form of an array
-  //     fields.options = this.getOptions_Dropdown(element);
-  //   }
-
-  //   // Extracting the options if the field type is 'Multiple Choice'
-  //   else if (fieldType === QType.MULTIPLE_CHOICE) {
-  //     // We get options in the form of an array
-  //     fields.options = this.getOptions_MULTIPLE_CHOICE(element);
-  //   }
-
-  //   // Extracting the options if the field type is 'Multiple Choice With Other'.
-  //   if (fieldType === QType.MULTIPLE_CHOICE_WITH_OTHER) {
-  //     // We get options in the form of an OBJECT which has two properties
-  //     //1. options - which contain options array
-  //     //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-  //     fields.options =
-  //       this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element).options;
-  //     fields.other = this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element).other;
-  //   }
-
-  //   // Extracting the options if the field type is 'Linear Scale'
-  //   if (fieldType === QType.LINEAR_SCALE) {
-  //     //We get options in an object {filteredOptions,filterLowerUpper}
-  //     //In Linear_Scale Left and Right Bounds are given and options are distributed uniformly between these bounds.
-  //     //These elements which we are saying Upper_bound and Lower_bound may be strings or characters.
-
-      
-  //     // Note
-  //     // We added one more attribute to fields `lowerUpperBounds` whose value will have an array containing LowerBound,UpperBound.
-  //     fields.options = this.getOptions_LINEAR_SCALE(element).filteredOptions;
-  //     fields.lowerUpperBounds =
-  //       this.getOptions_LINEAR_SCALE(element).filterLowerUpper;
-  //   }
-
-  //   // Extracting the options if the field type is `Checkbox Grid` or `Multiple Choice Grid`
-  //   if (
-  //     fieldType === QType.CHECKBOX_GRID ||
-  //     fieldType === QType.MULTIPLE_CHOICE_GRID
-  //   ) {
-  //     //We get options in form of an object
-  //     //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
-  //     fields.options = this.getOptions_GRID(element);
-  //   }
-  //   //Returning the object fields.It contains title , description , options (if that question has) keys .
-  //   return fields;
-  // }
-
-  // // Testing on Different Forms required
-  // getTitle(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the title of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is obtained by selecting the first child element of div with role=heading
-  //   // Return Type : String
-  //   let required = element.querySelector('div[role="heading"]');
-  //   required = required.children[0];
-
-  //   let content = "";
-
-  //   // Every new line is either inside a div or independent, hence has nodeName #text
-  //   Array.from(required.childNodes).forEach((element) => {
-  //     if (element.nodeName === "#text") {
-  //       content += element.textContent + "\n";
-  //     } else {
-  //       content += element.textContent + "\n";
-  //     }
-  //   });
-
-  //   // Remove trailing whitespace at the end
-  //   return content.trimEnd();
-  // }
-
-  // // Testing on Different Forms required
-  // getDescription(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the description of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is obtained by selecting the second child element of the parent element of div with role=heading
-  //   // Return Type : String (Returns null if no description is found!)
-  //   let required = element.querySelector('div[role="heading"]');
-  //   required = required.parentElement.children[1];
-  //   if (required === undefined || required.textContent === "") {
-  //     // console.log("There is no description for this box!");
-  //     return null;
-  //   }
-
-  //   let content = "";
-
-  //   // Every new line is either inside a div or independent, hence has nodeName #text
-  //   Array.from(required.childNodes).forEach((element) => {
-  //     if (element.nodeName === "#text") {
-  //       content += element.textContent + "\n";
-  //     } else {
-  //       content += element.textContent + "\n";
-  //     }
-  //   });
-  //   // console.log("checkpoint1");
-  //   // Remove trailing whitespace at the end
-  //   return content.trimEnd();
-  // }
-
-  // // Functions for Extracting Options
-  // //Extracting the options for field type = MultiCorrect With Other or MultiCorrect
-  // getOptions_MULTI_CORRECT(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the options of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-  //   // Return Type : Array (containing option's data) =>null if no options are present
-
-  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
-  //   if (!optionLabels || optionLabels.length === 0) {
-  //     // If no option labels are found, return an empty array
-  //     return [];
-  //   }
-
-  //   const options = [];
-  //   //we will go through all spans and extract its text content and store in our answer array.
-  //   optionLabels.forEach((label) => {
-  //     options.push(label.textContent.trim());
-  //   });
-
-  //   return options;
-  // }
-
-  // getOptions_MULTI_CORRECT_WITH_OTHER(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the options of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-  //   // Return Type : OBJECT which has two properties
-  //   //1. options - which contain options array
-  //   //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-  //   //it will contain an input field and in case no option match , we need to write our answer there
-
-  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
-  //   if (!optionLabels || optionLabels.length === 0) {
-  //     // If no option labels are found, return an empty array
-  //     return [];
-  //   }
-
-  //   const options = [];
-  //   //we will go through all spans and extract its text content and store in our answer array.
-  //   optionLabels.forEach((label) => {
-  //     options.push(label.textContent.trim());
-  //   });
-  //   // Remove the last option and add 'Other' field in the object
-  //   const lastOptionIndex = options.length - 1;
-  //   const otherOption = options.splice(lastOptionIndex, 1)[0];
-
-  //   return { options, other: otherOption };
-  // }
-
-  // //Extracting the options for field type = MultipleChoice With Other or MultipleChoice
-  // getOptions_MULTIPLE_CHOICE(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the options of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-  //   // Return Type : Array (containing option's data) =>null if no options are present
-
-  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
-  //   if (!optionLabels || optionLabels.length === 0) {
-  //     // If no option labels are found, return an empty array
-  //     return [];
-  //   }
-
-  //   const options = [];
-  //   //we will go through all spans and extract its text content and store in our answer array.
-  //   optionLabels.forEach((label) => {
-  //     options.push(label.textContent.trim());
-  //   });
-
-  //   return options;
-  // }
-
-  // getOptions_MULTIPLE_CHOICE_WITH_OTHER(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the options of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-  //   // Return Type : OBJECT which has two properties
-  //   //1. options - which contain options array
-  //   //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-  //   //it will contain an input field and in case no option match , we need to write our answer there
-
-  //   const optionLabels = element.querySelectorAll('span[dir="auto"]');
-  //   if (!optionLabels || optionLabels.length === 0) {
-  //     // If no option labels are found, return an empty array
-  //     return [];
-  //   }
-
-  //   const options = [];
-  //   //we will go through all spans and extract its text content and store in our answer array.
-  //   optionLabels.forEach((label) => {
-  //     options.push(label.textContent.trim());
-  //   });
-
-  //   // Remove the last option and add 'Other' field in the object
-  //   const lastOptionIndex = options.length - 1;
-  //   const otherOption = options.splice(lastOptionIndex, 1)[0];
-
-  //   return { options, other: otherOption };
-  // }
-
-  // //Extracting the options for field type = LinearScale
-  // getOptions_LINEAR_SCALE(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the options of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node for Lower and Upper bound is obtained by selecting the span whose role="presentation" and then need to traverse more
-  //   //since no attribute can be found which can help
-  //   //         -Option are present in in divs inside elements which has dir="auto".
-  //   // Return Type : Object containing two arrays - {filterLowerUpper,filteredOptions}
-  //   //filterLowerUpper- ArraySize=2 , contain lowerBound , upperBound
-  //   //filteredOptions- It will contain options.
-
-  //   const elementsWithHierarchy = element
-  //     .querySelector('span[role="presentation"]')
-  //     .querySelectorAll("div > div:last-child > div:last-child");
-  //   let lowerBound = null;
-  //   let upperBound = null;
-  //   //In elementWithHierarchy many nodes are present but we are sure 1st node is Lower bound and last node is Upper bound.
-  //   elementsWithHierarchy.forEach((el) => {
-  //     const textContent = el.textContent.trim();
-  //     if (lowerBound === null && textContent !== "") {
-  //       lowerBound = textContent; //Assigning lowerBound with 1st node
-  //     } else if (lowerBound !== null && textContent !== "") {
-  //       upperBound = textContent; //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound.
-  //     }
-  //   });
-
-  //   //Storing options in `options` array.
-  //   const optionElements = element.querySelectorAll('div[dir="auto"]');
-  //   const options = Array.from(optionElements).map((optionElement) =>
-  //     optionElement.textContent.trim()
-  //   );
-
-  //   // Storing LowerBound and UpperBound data
-  //   // lowerUpperBound array - the lower bound at the beginning (0th index) , and the upper bound at the end (1st index)
-  //   const lowerUpperBound = [lowerBound, upperBound];
-
-  //   // Filter out any null or empty string elements from the array
-  //   //This was creating an unexpected problem!
-  //   const filteredOptions = options.filter(
-  //     (item) => item !== null && item !== ""
-  //   );
-  //   const filterLowerUpper = lowerUpperBound.filter(
-  //     (item) => item !== null && item !== ""
-  //   );
-
-  //   return { filterLowerUpper, filteredOptions };
-  // }
-
-  // //Extracting the options for field type = Multiple Choice Grid or Checkbox Grid.
-  // getOptions_GRID(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the options of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is founded by Brute-force traversing no attribute can be found to be helpful.
-  //   //
-  //   // Return Type : Object containing 2 array
-  //   //              - 1st array will denote contents of row1,row2,row3...
-  //   //              -2nd array will denote contents of column1,column2,column3
-
-  //   //No property can be found so need to traverse this way only!
-  //   const path =
-  //     "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
-
-  //   //After getting to this path,
-  //   //its first child contains a div which contains all columns.
-  //   // and rest divs were for rows
-  //   //But between each row there was an empty div so we need to extract 2nd,4th,6th.. i.e even numbered divs**
-  //   const rows = element.querySelectorAll(`${path}:nth-child(2n)`);
-  //   const columns = element.querySelectorAll(`${path}:first-child > div`);
-
-  //   const gridArray = [];
-  //   //In these columns if we think in term of matrix then (0,0) place is left vacant so we sliced form 1 and take out content of each column.
-  //   const columnsArray = Array.from(columns)
-  //     .slice(1)
-  //     .map((column) => column.textContent.trim());
-  //   const rowsArray = Array.from(rows).map((row) => row.textContent.trim());
-
-  //   //Returning an Object containing 2 array
-  //   //      - 1st array will denote contents of row1,row2,row3...
-  //   //      -2nd array will denote contents of column1,column2,column3
-  //   return {
-  //     rows: rowsArray,
-  //     columns: columnsArray,
-  //   };
-  // }
-
-  // //Extracting the options for field type = Dropdown.
-  // getOptions_Dropdown(element) {
-  //   // Input Type: DOM Object
-  //   // Extracts the options of the question
-  //   // Tweak : - The extraction is based on the DOM tree
-  //   //         - The required node is found by selecting all divs having role="option" , inside this there are spans which contain options.
-  //   // Return Type : Array containing options.
-
-  //   const optionDivs = element.querySelectorAll('div[role="option"]');
-
-  //   if (!optionDivs || optionDivs.length === 0) {
-  //     return [];
-  //   }
-
-  //   const optionTexts = Array.from(optionDivs).map((div) => {
-  //     const span = div.querySelector("span");
-  //     if (span) {
-  //       return span.textContent.trim();
-  //     } else {
-  //       return null;
-  //     }
-  //   });
-
-  //   //All options were extracted but 1st element was `choose` so removed that.
-  //   // Remove the first element ("Choose" option) from the array
-  //   const optionsWithoutChoose = optionTexts.slice(1);
-  //   return optionsWithoutChoose;
-    // }
-    
-    */
-    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    return fields;
   }
 
-  // Function for Extracting Options
-  // Input Type: DOM Object
-  // Extracts the options of the question
-  // ! Return Type : An object containing the options field and its required value
-  // ! the return object may contain field other than options, as returned by the corresponding QuestionType
   getOptions(questionType, element) {
-    let optionLabels = null;
-    let options = [];
-
+    // Function for Extracting Options
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // ! Return Type : An object containing the options field and its required value
+    // ! the return object may contain field other than options, as returned by the corresponding QuestionType
+    
     switch (questionType) {
-      // Tweak : - The extraction is based on the DOM tree
-      //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-      // Return Type : object with options field containing an Array (containing option's data) =>null if no options are present
+
+      // Extracting the options if the field type is MultiCorrect
       case QType.MULTI_CORRECT:
-        optionLabels = element.querySelectorAll('span[dir="auto"]');
-        if (!optionLabels || optionLabels.length === 0) {
-          // If no option labels are found, return an empty array
-          return { options: [] };
-        }
+        return this.getOptions_MULTI_CORRECT(element);
 
-        options = [];
-        //we will go through all spans and extract its text content and store in our answer array.
-        optionLabels.forEach((label) => {
-          options.push(label.textContent.trim());
-        });
+      // Extracting the options if the field type is MultiCorrect_WITH_OTHER
 
-        return { options: options };
-        break;
-
-      // Tweak : - The extraction is based on the DOM tree
-      //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-      // Return Type : OBJECT which has two properties
-      //1. options - which contain options array
-      //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-      //it will contain an input field and in case no option match , we need to write our answer there
       case QType.MULTI_CORRECT_WITH_OTHER:
-        optionLabels = element.querySelectorAll('span[dir="auto"]');
-        if (!optionLabels || optionLabels.length === 0) {
-          // If no option labels are found, return an empty array
-          return { options: [] };
-        }
+        // We get options in the form of an OBJECT which has two properties
+        //1. options - which contain options array
+        //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
 
-        options = [];
-        //we will go through all spans and extract its text content and store in our answer array.
-        optionLabels.forEach((label) => {
-          options.push(label.textContent.trim());
-        });
-        // Remove the last option and add 'Other' field in the object
-        let lastOptionIndex = options.length - 1;
-        let otherOption = options.splice(lastOptionIndex, 1)[0];
+        return this.getOptions_MULTI_CORRECT_WITH_OTHER(element);
 
-        return { options: options, other: otherOption };
-        break;
+      // Extracting the options if the field type is 'Multiple Choice'
 
-      // Tweak : - The extraction is based on the DOM tree
-      //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-      // Return Type : object with options field in the following format { options: Array (containing option's data) =>null if no options are present }
       case QType.MULTIPLE_CHOICE:
-        optionLabels = element.querySelectorAll('span[dir="auto"]');
-        if (!optionLabels || optionLabels.length === 0) {
-          // If no option labels are found, return an empty array
-          return { options: [] };
-        }
+        return this.getOptions_MULTIPLE_CHOICE(element);
 
-        options = [];
-        //we will go through all spans and extract its text content and store in our answer array.
-        optionLabels.forEach((label) => {
-          options.push(label.textContent.trim());
-        });
+      // Extracting the options if the field type is 'Multiple Choice With Other'.
 
-        return { options: options };
-        break;
-
-      // Return Type : OBJECT which has two properties
-      // 1. options - which contain options array
-      // 2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-      // it will contain an input field and in case no option match , we need to write our answer there
       case QType.MULTIPLE_CHOICE_WITH_OTHER:
-        optionLabels = element.querySelectorAll('span[dir="auto"]');
-        if (!optionLabels || optionLabels.length === 0) {
-          // If no option labels are found, return an empty array
-          return { options: [] };
-        }
+        // We get options in the form of an OBJECT which has two properties
+        //1. options - which contain options array
+        //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
 
-        options = [];
-        //we will go through all spans and extract its text content and store in our answer array.
-        optionLabels.forEach((label) => {
-          options.push(label.textContent.trim());
-        });
+        return this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element);
 
-        // Remove the last option and add 'Other' field in the object
-        lastOptionIndex = options.length - 1;
-        otherOption = options.splice(lastOptionIndex, 1)[0];
+      // Extracting the options if the field type is 'Linear Scale'
 
-        return { options: options, other: otherOption };
-        break;
-
-      // Tweak : - The extraction is based on the DOM tree
-      //         - The required node for Lower and Upper bound is obtained by selecting the span whose role="presentation" and then need to traverse more
-      // since no attribute can be found which can help
-      //         -Option are present in in divs inside elements which has dir="auto".
-      // Return Type : Object containing two arrays - {filterLowerUpper,filteredOptions}
-      // filterLowerUpper- ArraySize=2 , contain lowerBound , upperBound
-      // filteredOptions- It will contain options.
       case QType.LINEAR_SCALE:
-        let elementsWithHierarchy = element
-          .querySelector('span[role="presentation"]')
-          .querySelectorAll("div > div:last-child > div:last-child");
-        let lowerBound = null;
-        let upperBound = null;
-        //In elementWithHierarchy many nodes are present but we are sure 1st node is Lower bound and last node is Upper bound.
-        elementsWithHierarchy.forEach((el) => {
-          let textContent = el.textContent.trim();
-          if (lowerBound === null && textContent !== "") {
-            lowerBound = textContent; //Assigning lowerBound with 1st node
-          } else if (lowerBound !== null && textContent !== "") {
-            upperBound = textContent; //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound.
-          }
-        });
+        //We get options in an object {filteredOptions,filterLowerUpper}
+        //In Linear_Scale Left and Right Bounds are given and options are distributed uniformly between these bounds.
+        //These elements which we are saying Upper_bound and Lower_bound may be strings or characters.
 
-        //Storing options in `options` array.
-        let optionElements = element.querySelectorAll('div[dir="auto"]');
-        options = Array.from(optionElements).map((optionElement) =>
-          optionElement.textContent.trim()
-        );
+        /*
+        Note
+        We added one more attribute to fields `lowerUpperBounds` whose value will have an array containing LowerBound,UpperBound.
+        */
+        return this.getOptions_LINEAR_SCALE(element);
 
-        // Storing LowerBound and UpperBound data
-        // lowerUpperBound array - the lower bound at the beginning (0th index) , and the upper bound at the end (1st index)
-        let lowerUpperBound = [lowerBound, upperBound];
+      // Extracting the options if the field type is `Checkbox Grid` or `Multiple Choice Grid`
 
-        // Filter out any null or empty string elements from the array
-        //This was creating an unexpected problem!
-        const filteredOptions = options.filter(
-          (item) => item !== null && item !== ""
-        );
-        const filterLowerUpper = lowerUpperBound.filter(
-          (item) => item !== null && item !== ""
-        );
-
-        return { lowerUpperBounds: filterLowerUpper, options: filteredOptions };
-        break;
-
-      // Tweak : - The extraction is based on the DOM tree
-      //         - The required node is founded by Brute-force traversing no attribute can be found to be helpful.
-      //
-      // Return Type : Object containing 2 array
-      //              - 1st array will denote contents of row1,row2,row3...
-      //              -2nd array will denote contents of column1,column2,column3
       case QType.CHECKBOX_GRID:
       case QType.MULTIPLE_CHOICE_GRID:
-        //No property can be found so need to traverse this way only!
-        let path =
-          "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
+        //We get options in form of an object
+        //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
 
-        //After getting to this path,
-        //its first child contains a div which contains all columns.
-        // and rest divs were for rows
-        //But between each row there was an empty div so we need to extract 2nd,4th,6th.. i.e even numbered divs**
-        const rows = element.querySelectorAll(`${path}:nth-child(2n)`);
-        const columns = element.querySelectorAll(`${path}:first-child > div`);
+        return this.getOptions_GRID(element);
 
-        const gridArray = [];
-        //In these columns if we think in term of matrix then (0,0) place is left vacant so we sliced form 1 and take out content of each column.
-        const columnsArray = Array.from(columns)
-          .slice(1)
-          .map((column) => column.textContent.trim());
-        const rowsArray = Array.from(rows).map((row) => row.textContent.trim());
+      // Extracting the options if the field type is Dropdown
 
-        //Returning an Object containing 2 array
-        //      - 1st array will denote contents of row1,row2,row3...
-        //      -2nd array will denote contents of column1,column2,column3
-        return {
-          options: {
-            rows: rowsArray,
-            columns: columnsArray,
-          },
-        };
-        break;
-
-      // Tweak : - The extraction is based on the DOM tree
-      //         - The required node is found by selecting all divs having role="option" , inside this there are spans which contain options.
-      // Return Type : Object with options field value is an Array containing the required options.
       case QType.DROPDOWN:
-        const optionDivs = element.querySelectorAll('div[role="option"]');
-        if (!optionDivs || optionDivs.length === 0) {
-          return [];
-        }
-
-        const optionTexts = Array.from(optionDivs).map((div) => {
-          const span = div.querySelector("span");
-          if (span) {
-            return span.textContent.trim();
-          } else {
-            return null;
-          }
-        });
-
-        //All options were extracted but 1st element was `choose` so removed that.
-        // Remove the first element ("Choose" option) from the array
-        const optionsWithoutChoose = optionTexts.slice(1);
-        return { options: optionsWithoutChoose };
-        break;
+        return this.getOptions_Dropdown(element);
     }
   }
 
@@ -632,5 +143,236 @@ export class FieldsExtractorEngine {
     // console.log("checkpoint1");
     // Remove trailing whitespace at the end
     return content.trimEnd();
+  }
+
+  // Functions for Extracting Options
+  //Extracting the options for field type = MultiCorrect With Other or MultiCorrect
+  getOptions_MULTI_CORRECT(element) {
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // Tweak : - The extraction is based on the DOM tree
+    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+    // Return Type : Array (containing option's data) =>null if no options are present
+
+    const optionLabels = element.querySelectorAll('span[dir="auto"]');
+    if (!optionLabels || optionLabels.length === 0) {
+      // If no option labels are found, return an empty array
+      return { options: [] };
+    }
+
+    options = [];
+    //we will go through all spans and extract its text content and store in our answer array.
+    optionLabels.forEach((label) => {
+      options.push(label.textContent.trim());
+    });
+
+    return { options: options };
+  }
+
+
+  getOptions_MULTI_CORRECT_WITH_OTHER(element) {
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // Tweak : - The extraction is based on the DOM tree
+    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+    // Return Type : OBJECT which has two properties
+    //1. options - which contain options array
+    //2. other - which contain `other:` which need to deal in separate way to ask Chatbot 
+    //it will contain an input field and in case no option match , we need to write our answer there
+
+    const optionLabels = element.querySelectorAll('span[dir="auto"]');
+    if (!optionLabels || optionLabels.length === 0) {
+      // If no option labels are found, return an empty array
+      return { options: [] };
+    }
+
+    let options = [];
+    //we will go through all spans and extract its text content and store in our answer array.
+    optionLabels.forEach((label) => {
+      options.push(label.textContent.trim());
+    });
+    // Remove the last option and add 'Other' field in the object
+    let lastOptionIndex = options.length - 1;
+    let otherOption = options.splice(lastOptionIndex, 1)[0];
+
+    return { options: options, other: otherOption };
+
+  }
+
+
+  //Extracting the options for field type = MultipleChoice With Other or MultipleChoice
+  getOptions_MULTIPLE_CHOICE(element) {
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // Tweak : - The extraction is based on the DOM tree
+    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+    // Return Type : Array (containing option's data) =>null if no options are present
+
+    const optionLabels = element.querySelectorAll('span[dir="auto"]');
+    if (!optionLabels || optionLabels.length === 0) {
+      // If no option labels are found, return an empty array
+      return { options: [] };
+    }
+
+    options = [];
+    //we will go through all spans and extract its text content and store in our answer array.
+    optionLabels.forEach((label) => {
+      options.push(label.textContent.trim());
+    });
+
+    return { options: options };
+  }
+
+
+  getOptions_MULTIPLE_CHOICE_WITH_OTHER(element) {
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // Tweak : - The extraction is based on the DOM tree
+    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+    // Return Type : OBJECT which has two properties
+    //1. options - which contain options array
+    //2. other - which contain `other:` which need to deal in separate way to ask Chatbot 
+    //it will contain an input field and in case no option match , we need to write our answer there
+
+    const optionLabels = element.querySelectorAll('span[dir="auto"]');
+    if (!optionLabels || optionLabels.length === 0) {
+      // If no option labels are found, return an empty array
+      return { options: [] };
+    }
+
+    let options = [];
+    //we will go through all spans and extract its text content and store in our answer array.
+    optionLabels.forEach((label) => {
+      options.push(label.textContent.trim());
+    });
+
+    // Remove the last option and add 'Other' field in the object
+    let lastOptionIndex = options.length - 1;
+    let otherOption = options.splice(lastOptionIndex, 1)[0];
+
+    return { options: options, other: otherOption };
+
+  }
+
+
+  //Extracting the options for field type = LinearScale
+  getOptions_LINEAR_SCALE(element) {
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // Tweak : - The extraction is based on the DOM tree
+    //         - The required node for Lower and Upper bound is obtained by selecting the span whose role="presentation" and then need to traverse more 
+    //since no attribute can be found which can help
+    //         -Option are present in in divs inside elements which has dir="auto".
+    // Return Type : Object containing two arrays - {filterLowerUpper,filteredOptions}
+    //filterLowerUpper- ArraySize=2 , contain lowerBound , upperBound
+    //filteredOptions- It will contain options.
+
+    let elementsWithHierarchy = element
+      .querySelector('span[role="presentation"]')
+      .querySelectorAll("div > div:last-child > div:last-child");
+    let lowerBound = null;
+    let upperBound = null;
+    //In elementWithHierarchy many nodes are present but we are sure 1st node is Lower bound and last node is Upper bound.
+    elementsWithHierarchy.forEach((elem) => {
+      let textContent = elem.textContent.trim();
+      if (lowerBound === null && textContent !== "") {
+        lowerBound = textContent; //Assigning lowerBound with 1st node
+      } else if (lowerBound !== null && textContent !== "") {
+        upperBound = textContent; //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound.
+      }
+    });
+
+    //Storing options in `options` array.
+    let optionElements = element.querySelectorAll('div[dir="auto"]');
+    let options = Array.from(optionElements).map((optionElement) =>
+      optionElement.textContent.trim()
+    );
+
+    // Storing LowerBound and UpperBound data
+    // lowerUpperBound array - the lower bound at the beginning (0th index) , and the upper bound at the end (1st index)
+    let lowerUpperBound = [lowerBound, upperBound];
+
+    // Filter out any null or empty string elements from the array
+    //This was creating an unexpected problem!
+    const filteredOptions = options.filter(
+      (item) => item !== null && item !== ""
+    );
+    const filterLowerUpper = lowerUpperBound.filter(
+      (item) => item !== null && item !== ""
+    );
+
+    return { lowerUpperBounds: filterLowerUpper, options: filteredOptions };
+  }
+
+
+  //Extracting the options for field type = Multiple Choice Grid or Checkbox Grid.
+  getOptions_GRID(element) {
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // Tweak : - The extraction is based on the DOM tree
+    //         - The required node is founded by Brute-force traversing no attribute can be found to be helpful.
+    //         
+    // Return Type : Object containing 2 array 
+    //              - 1st array will denote contents of row1,row2,row3...
+    //              -2nd array will denote contents of column1,column2,column3
+
+
+    //No property can be found so need to traverse this way only!
+    let path =
+      "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
+
+    //After getting to this path,
+    //its first child contains a div which contains all columns.
+    // and rest divs were for rows
+    //But between each row there was an empty div so we need to extract 2nd,4th,6th.. i.e even numbered divs**
+    const rows = element.querySelectorAll(`${path}:nth-child(2n)`);
+    const columns = element.querySelectorAll(`${path}:first-child > div`);
+
+    const gridArray = [];
+    //In these columns if we think in term of matrix then (0,0) place is left vacant so we sliced form 1 and take out content of each column.
+    const columnsArray = Array.from(columns)
+      .slice(1)
+      .map((column) => column.textContent.trim());
+    const rowsArray = Array.from(rows).map((row) => row.textContent.trim());
+
+    //Returning an Object containing 2 array
+    //      - 1st array will denote contents of row1,row2,row3...
+    //      -2nd array will denote contents of column1,column2,column3
+    return {
+      options: {
+        rows: rowsArray,
+        columns: columnsArray,
+      },
+    };
+  }
+
+
+
+  //Extracting the options for field type = Dropdown.
+  getOptions_Dropdown(element) {
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // Tweak : - The extraction is based on the DOM tree
+    //         - The required node is found by selecting all divs having role="option" , inside this there are spans which contain options.
+    // Return Type : Array containing options.
+
+    const optionDivs = element.querySelectorAll('div[role="option"]');
+    if (!optionDivs || optionDivs.length === 0) {
+      return { options: [] };
+    }
+
+    const optionTexts = Array.from(optionDivs).map((div) => {
+      const span = div.querySelector("span");
+      if (span) {
+        return span.textContent.trim();
+      } else {
+        return null;
+      }
+    });
+
+    //All options were extracted but 1st element was `choose` so removed that.
+    // Remove the first element ("Choose" option) from the array
+    const optionsWithoutChoose = optionTexts.slice(1);
+    return { options: optionsWithoutChoose };
   }
 }


### PR DESCRIPTION
Summary : `getFields()` function returns a fields object which contains the
   description of the question.

`getOptions()` is now a single function which requires you to pass the question type of the question and the element whose options are to be fetched rather than calling a separate `getOptions_<QuestionType>()` for each type of question.

The conditional checking has been done with switch-case for better code quality rather than if else-if etc

The return type of getOptions() is an object itself rather than the options array, and the remaining fields are being attached to the fields attribute via object restructuring, no need to explicitly attach the object attribute.

---

code architecture
```js
getFields() {
fields = {...}
// the new attributes added to the fields object
fields = {...fields, ...this.getOptions(...)};
}

getOptions(questionType, element) {
// gets the required field attributes from the particular questionType and returns an object containing those
}

... // misc code 

```