### PR TITLE
Extract DOM objects and option data for all question types

### DIFF
--- a/src/filler/engines/fields-extractor-engine.js
+++ b/src/filler/engines/fields-extractor-engine.js
@@ -20,13 +20,13 @@ export class FieldsExtractorEngine {
     // the function is is highly abstracted
 
     // TODO : the getOptions() can be broken down into further functions if needed, just ensure that the return type is consistent so that the below line still works
-    let optionFields = this.getOptions(fieldType, element);
+    let optionFields = this.getParams(fieldType, element);
     fields = { ...fields, ...optionFields };
 
     return fields;
   }
 
-  getOptions(questionType, element) {
+  getParams(questionType, element) {
     // Function for Extracting Options
     // Input Type: DOM Object
     // Extracts the options of the question
@@ -37,7 +37,7 @@ export class FieldsExtractorEngine {
 
       // Extracting the options if the field type is MultiCorrect
       case QType.MULTI_CORRECT:
-        return this.getOptions_MULTI_CORRECT(element);
+        return this.getParamsMultiCorrect(element);
 
       // Extracting the options if the field type is MultiCorrect_WITH_OTHER
 
@@ -46,12 +46,12 @@ export class FieldsExtractorEngine {
         //1. options - which contain options array
         //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
 
-        return this.getOptions_MULTI_CORRECT_WITH_OTHER(element);
+        return this.getParamsMultiCorrectWithOther(element);
 
       // Extracting the options if the field type is 'Multiple Choice'
 
       case QType.MULTIPLE_CHOICE:
-        return this.getOptions_MULTIPLE_CHOICE(element);
+        return this.getParamsMultipleChoice(element);
 
       // Extracting the options if the field type is 'Multiple Choice With Other'.
 
@@ -60,7 +60,7 @@ export class FieldsExtractorEngine {
         //1. options - which contain options array
         //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
 
-        return this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element);
+        return this.getParamsMultipleChoiceWithOther(element);
 
       // Extracting the options if the field type is 'Linear Scale'
 
@@ -73,81 +73,81 @@ export class FieldsExtractorEngine {
         Note
         We added one more attribute to fields `lowerUpperBounds` whose value will have an array containing LowerBound,UpperBound.
         */
-        return this.getOptions_LINEAR_SCALE(element);
+        return this.getParamsLinearScale(element);
 
       // Extracting the options if the field type is `Checkbox Grid` or `Multiple Choice Grid`
       case QType.CHECKBOX_GRID:
-        return this.getOptions_CHECKBOXGRID(element);
+        return this.getParamsCheckboxGrid(element);
 
       case QType.MULTIPLE_CHOICE_GRID:
         //We get options in form of an object
         //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
-        return this.getOptions_MULTIPLECHOICEGRID(element);
+        return this.getParamsMultipleChoiceGrid(element);
 
       // Extracting the options if the field type is Dropdown
       case QType.DROPDOWN:
-        return this.getOptions_Dropdown(element);
+        return this.getParamsDropdown(element);
 
       // Extracting the options if the field type is 'Text'.
       case QType.TEXT:
         //
-        return this.getDom_TEXT(element);
+        return this.getDomText(element);
 
       // Extracting the options if the field type is 'Paragraph'.
       case QType.PARAGRAPH:
-        return this.getDom_paragraph(element);
+        return this.getDomTextParagraph(element);
 
       // Extracting the options if the field type is 'Email'.
       case QType.TEXT_EMAIL:
-        return this.getDom_email(element);
+        return this.getDomTextEmail(element);
 
       // Extracting the options if the field type is 'Text Numeric'.
       case QType.TEXT_NUMERIC:
-        return this.getDom_TEXT(element);
+        return this.getDomText(element);
 
       // Extracting the options if the field type is 'Text Telephonic'.
       case QType.TEXT_TEL:
-        return this.getDom_texttel(element);
+        return this.getDomTextTel(element);
 
       // Extracting the options if the field type is 'Text URL'.
       case QType.TEXT_URL:
-        return this.getDom_texturl(element);
+        return this.getDomTextUrl(element);
 
       // Extracting the options if the field type is 'Date'.
       case QType.DATE:
-        return this.getDom_date(element);
+        return this.getDomDate(element);
 
       // Extracting the options if the field type is 'Date And Time'.
       case QType.DATE_AND_TIME:
-        return this.getDom_dateandtime(element);
+        return this.getDomDateAndTime(element);
 
       // Extracting the options if the field type is 'Time'.
       case QType.TIME:
-        return this.getDom_time(element);
+        return this.getDomTime(element);
 
       // Extracting the options if the field type is 'Duration'.
       case QType.DURATION:
-        return this.getDom_duration(element);
+        return this.getDomDuration(element);
 
       // Extracting the options if the field type is 'Date without Year'.
       case QType.DATE_WITHOUT_YEAR:
-        return this.getDom_date_without_year(element);
+        return this.getDomDateWithoutYear(element);
 
       // Extracting the options if the field type is 'Date without Year with Time'.
       case QType.DATE_TIME_WITHOUT_YEAR:
-        return this.getDom_date_time_without_year(element);
+        return this.getDomDateTimeWithoutYear(element);
 
       // Extracting the options if the field type is 'Date with Time and Meridiem'.
       case QType.DATE_TIME_WITH_MERIDIEM:
-        return this.getDom_date_time_with_meridiem(element);
+        return this.getDomDateTimeWithMeridiem(element);
 
       // Extracting the options if the field type is 'Time and Meridiem'.
       case QType.TIME_WITH_MERIDIEM:
-        return this.getDom_time_with_meridiem(element);
+        return this.getDomTimeWithMeridiem(element);
 
       // Extracting the options if the field type is 'Date without Year with Time and Meridiem'.
       case QType.DATE_TIME_WITH_MERIDIEM_WITHOUT_YEAR:
-        return this.getDom_date_time_with_meridiem_withoutyear(element);
+        return this.getDomDateTimeWithMeridiemWithoutYear(element);
     }
   }
 
@@ -207,7 +207,7 @@ export class FieldsExtractorEngine {
 
   // Functions for Extracting Options
   //Extracting the options for field type = MultiCorrect With Other or MultiCorrect
-  getOptions_MULTI_CORRECT(element) {
+  getParamsMultiCorrect(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -221,25 +221,25 @@ export class FieldsExtractorEngine {
     }
 
     //Extracting divs which has radio buttons.
-    const super_Divs = element.querySelectorAll('div[role="checkbox"]');
+    const superDivs = element.querySelectorAll('div[role="checkbox"]');
     const clickElements = [];
-    //For each option child of 2nd child of super_Divs' div will contain a div whose 1st child is responsible on selecting an option.
+    //For each option child of 2nd child of superDivs' div will contain a div whose 1st child is responsible on selecting an option.
     //By using click() method on clickDiv.firstElementChild which we pushed in array 'ClickElements' will mark that particular option
-    super_Divs.forEach((optionDiv) => {
+    superDivs.forEach((optionDiv) => {
       const thirdDiv = optionDiv.children[2];
       const clickDiv = thirdDiv.firstElementChild;
       clickElements.push(clickDiv.firstElementChild);
     });
     const options = [];
-    const optiondata = [];
-    //we will go through all spans and extract its text content and store in our answer array as optiondata.
+    const optionData = [];
+    //we will go through all spans and extract its text content and store in our answer array as optionData.
     optionLabels.forEach((label) => {
-      optiondata.push(label.textContent.trim());
+      optionData.push(label.textContent.trim());
     });
 
-    if (clickElements.length > 0 && clickElements.length === optiondata.length) {
+    if (clickElements.length > 0 && clickElements.length === optionData.length) {
       for (let i = 0; i < clickElements.length; i++) {
-        options.push({ option_data: optiondata[i], option_dom: clickElements[i] });
+        options.push({ data: optionData[i], dom: clickElements[i] });
       }
     }
 
@@ -247,7 +247,7 @@ export class FieldsExtractorEngine {
   }
 
 
-  getOptions_MULTI_CORRECT_WITH_OTHER(element) {
+  getParamsMultiCorrectWithOther(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -264,32 +264,32 @@ export class FieldsExtractorEngine {
     }
 
     //Extracting divs which has role=checkbox.
-    const super_Divs = element.querySelectorAll('div[role="checkbox"]');
+    const superDivs = element.querySelectorAll('div[role="checkbox"]');
     const clickElements = [];
-    //For each option child of 2nd child of super_Divs' div will contain a div which is responsible on selecting an option.
+    //For each option child of 2nd child of superDivs' div will contain a div which is responsible on selecting an option.
     //By using click() method on clickDiv which we pushed in array 'ClickOption' will mark that particular option
-    super_Divs.forEach((optionDiv) => {
+    superDivs.forEach((optionDiv) => {
       const thirdDiv = optionDiv.children[2];
       const clickDiv = thirdDiv.firstElementChild;
       clickElements.push(clickDiv.firstElementChild);
     });
 
     const options = [];
-    const optiondata = [];
+    const optionData = [];
     //we will go through all spans and extract its text content and store in an array.
     optionLabels.forEach((label) => {
-      optiondata.push(label.textContent.trim());
+      optionData.push(label.textContent.trim());
     });
-    // Remove the last option and add 'other_option' field in the object, `other_option` is itself an object containing option_data, option_dom,inputBoxdom
-    const lastOptionIndex = optiondata.length - 1;
-    const otherOption = optiondata.splice(lastOptionIndex, 1)[0];
-    console.log(otherOption)
+    // Remove the last option and add 'other_option' field in the object, `other_option` is itself an object containing option_data, option_dom,inputBoxDom
+    const lastOptionIndex = optionData.length - 1;
+    const otherOption = optionData.splice(lastOptionIndex, 1)[0];
+    // console.log(otherOption)
     const other_option = []
-    if (clickElements.length > 0 && clickElements.length === optiondata.length + 1) {
+    if (clickElements.length > 0 && clickElements.length === optionData.length + 1) {
       for (let i = 0; i < clickElements.length - 1; i++) {
-        options.push({ data: optiondata[i], dom: clickElements[i], });
+        options.push({ data: optionData[i], dom: clickElements[i], });
       }
-      const input_in_mcwo = element.querySelector('input[dir="auto"]');
+      const input_in_mcwo = element.querySelector('input[dir="auto"]');// mcwo is an acronym for multi choice with others
       other_option.push({ data: otherOption, dom: clickElements[clickElements.length - 1], inputBoxDom: input_in_mcwo });
     }
 
@@ -299,7 +299,7 @@ export class FieldsExtractorEngine {
 
 
   //Extracting the options for field type = MultipleChoice With Other or MultipleChoice
-  getOptions_MULTIPLE_CHOICE(element) {
+  getParamsMultipleChoice(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -313,26 +313,26 @@ export class FieldsExtractorEngine {
     }
 
     //Extracting divs which has radio buttons.
-    const super_Divs = element.querySelectorAll('div[role="radio"]');
+    const superDivs = element.querySelectorAll('div[role="radio"]');
     const clickElements = [];
-    //For each option child of 2nd child of super_Divs' div will contain a div which is responsible on selecting an option.
+    //For each option child of 2nd child of superDivs' div will contain a div which is responsible on selecting an option.
     //By using click() method on clickDiv which we pushed in array 'ClickOption' will mark that particular option
-    super_Divs.forEach((optionDiv) => {
+    superDivs.forEach((optionDiv) => {
       const thirdDiv = optionDiv.children[2];
       const clickDiv = thirdDiv.firstElementChild;
       clickElements.push(clickDiv);
     });
 
     const options = [];
-    const optiondata = [];
+    const optionData = [];
     //we will go through all spans and extract its text content and store in option_data array.
     optionLabels.forEach((label) => {
-      optiondata.push(label.textContent.trim());
+      optionData.push(label.textContent.trim());
     });
 
-    if (clickElements.length > 0 && clickElements.length === optiondata.length) {
+    if (clickElements.length > 0 && clickElements.length === optionData.length) {
       for (let i = 0; i < clickElements.length; i++) {
-        options.push({ option_data: optiondata[i], option_dom: clickElements[i] });
+        options.push({ data: optionData[i], dom: clickElements[i] });
       }
     }
 
@@ -340,7 +340,7 @@ export class FieldsExtractorEngine {
   }
 
 
-  getOptions_MULTIPLE_CHOICE_WITH_OTHER(element) {
+  getParamsMultipleChoiceWithOther(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -357,45 +357,45 @@ export class FieldsExtractorEngine {
     }
 
     //Extracting divs which has radio buttons.
-    const super_Divs = element.querySelectorAll('div[role="radio"]');
+    const superDivs = element.querySelectorAll('div[role="radio"]');
     const clickElements = [];
-    //For each option child of 2nd child of super_Divs' div will contain a div which is responsible on selecting an option.
+    //For each option child of 2nd child of superDivs' div will contain a div which is responsible on selecting an option.
     //By using click() method on clickDiv which we pushed in array 'ClickOption' will mark that particular option
-    super_Divs.forEach((optionDiv) => {
+    superDivs.forEach((optionDiv) => {
       const thirdDiv = optionDiv.children[2];
       const clickDiv = thirdDiv.firstElementChild;
       clickElements.push(clickDiv.firstElementChild);
     });
 
     const options = [];
-    const optiondata = [];
+    const optionData = [];
     //we will go through all spans and extract its text content and store in our answer array.
     optionLabels.forEach((label) => {
-      optiondata.push(label.textContent.trim());
+      optionData.push(label.textContent.trim());
     });
 
-    // console.log(optiondata)
+    // console.log(optionData)
     // Remove the last option and add 'Other' field in the object
-    const lastOptionIndex = optiondata.length - 1;
-    const otherOption = optiondata.splice(lastOptionIndex, 1)[0];
-    console.log(otherOption)
-    const other_dom = []
-    if (clickElements.length > 0 && clickElements.length === optiondata.length + 1) {
+    const lastOptionIndex = optionData.length - 1;
+    const otherOption = optionData.splice(lastOptionIndex, 1)[0];
+    // console.log(otherOption)
+    const otherDom = []
+    if (clickElements.length > 0 && clickElements.length === optionData.length + 1) {
       for (let i = 0; i < clickElements.length - 1; i++) {
-        options.push({ data: optiondata[i], dom: clickElements[i] });
+        options.push({ data: optionData[i], dom: clickElements[i] });
       }
-      const input_in_mcwo = element.querySelector('input[dir="auto"]');
+      const input_in_mcwo = element.querySelector('input[dir="auto"]');  // mcwo is an acronym for multiple choice with others
 
-      other_dom.push({ other_data: otherOption, other_dom: clickElements[clickElements.length - 1], inputBoxDom: input_in_mcwo });
+      otherDom.push({ data: otherOption, dom: clickElements[clickElements.length - 1], inputBoxDom: input_in_mcwo });
     }
 
-    return { options: options, other: other_dom };
+    return { options: options, other: otherDom };
 
   }
 
 
   //Extracting the options for field type = LinearScale
-  getOptions_LINEAR_SCALE(element) {
+  getParamsLinearScale(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -412,10 +412,10 @@ export class FieldsExtractorEngine {
     let lowerBound = null;
     let upperBound = null;
 
-    const super_Divs = element.querySelectorAll('div[role="radio"]');
+    const superDivs = element.querySelectorAll('div[role="radio"]');
     const domsArray = [];
 
-    super_Divs.forEach((optionDiv) => {
+    superDivs.forEach((optionDiv) => {
       const thirdDiv = optionDiv.children[2];
       const clickDiv = thirdDiv.firstElementChild;
       const targetDom = clickDiv.firstElementChild;
@@ -459,7 +459,7 @@ export class FieldsExtractorEngine {
 
 
   //Extracting the options for field type = Multiple Choice Grid.
-  getOptions_MULTIPLECHOICEGRID(element) {
+  getParamsMultipleChoiceGrid(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -505,11 +505,11 @@ export class FieldsExtractorEngine {
 
     });
 
-    let option_dom = []
+    let optionDom = []
     for (let i = 0; i < rowsArray.length; i++) {
       for (let j = 0; j < columnsArray.length; j++) {
         //lets consider 2X3 multiple choice grid then option dom will be [{option:column1 dom:dom1} , {option:column2 dom:dom2} , {option:column3 dom:dom3} , {option:column1 dom:dom4} , {option:column2 dom:dom5} ,{option:column3 dom:dom6}]
-        option_dom.push({ option: columnsArray[j], dom: optionsArray[i][j] })
+        optionDom.push({ data: columnsArray[j], dom: optionsArray[i][j] })
       }
     }
     let row_col_dom = []
@@ -518,7 +518,7 @@ export class FieldsExtractorEngine {
     for (let i = 0; i < rowsArray.length; i++) {
       arr = [];
       for (let p = q; p < columnsArray.length * (i + 1); p++, q++) {
-        arr.push(option_dom[p]);
+        arr.push(optionDom[p]);
       }
       row_col_dom.push({ row: rowsArray[i], cols: arr })
     }
@@ -529,7 +529,7 @@ export class FieldsExtractorEngine {
   }
 
   //Extracting the options for field type = Checkbox Grid.
-  getOptions_CHECKBOXGRID(element) {
+  getParamsCheckboxGrid(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -590,7 +590,7 @@ export class FieldsExtractorEngine {
 
 
   //Extracting the options for field type = Dropdown.
-  getOptions_Dropdown(element) {
+  getParamsDropdown(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
@@ -609,13 +609,13 @@ export class FieldsExtractorEngine {
       const span = optionDiv.querySelector("span");
 
       if (span) {
-        options.push({ option_data: span.textContent.trim(), option_dom: optionDiv });
+        options.push({ data: span.textContent.trim(), dom: optionDiv });
       }
     }
     return { options: options };
   }
 
-  getDom_TEXT(element) {
+  getDomText(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="TEXT"
     // Return Type :Returns the input field.
@@ -623,7 +623,7 @@ export class FieldsExtractorEngine {
     return { dom: inputField };
   }
 
-  getDom_email(element) {
+  getDomTextEmail(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="TEXT_EMAIL"
     // Return Type :Returns the input field.
@@ -631,7 +631,7 @@ export class FieldsExtractorEngine {
     let inputField = element.querySelectorAll('input[type=text], input[type=email]')
     return { dom: inputField };
   }
-  getDom_paragraph(element) {
+  getDomTextParagraph(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="PARAGRAPH"
     // Return Type :Returns the input field.
@@ -639,7 +639,7 @@ export class FieldsExtractorEngine {
     let inputField = element.querySelectorAll('textarea')
     return { dom: inputField };
   }
-  getDom_date(element) {
+  getDomDate(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DATE"
     // Return Type :Returns the input field.Its returns input field as a Nodelist
@@ -647,7 +647,7 @@ export class FieldsExtractorEngine {
     let inputField = element.querySelectorAll('input[type=text], input[type=date]')
     return { dom: inputField };
   }
-  getDom_dateandtime(element) {
+  getDomDateAndTime(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DATE_AND_TIME"
     // Return Type :Returns the input field.Its return in form of a Nodelist
@@ -656,7 +656,7 @@ export class FieldsExtractorEngine {
     let inputField = element.querySelectorAll('input[type=text], input[type=date]')
     return { dom: inputField };
   }
-  getDom_duration(element) {
+  getDomDuration(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DURATION"
     // Return Type :Returns the input field.Its return in form of Nodelist 
@@ -664,7 +664,7 @@ export class FieldsExtractorEngine {
     let inputField = element.querySelectorAll('input[type=text]')
     return { dom: inputField };
   }
-  getDom_date_without_year(element) {
+  getDomDateWithoutYear(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DATE_WITHOUT_YEAR"
     // Return Type :Returns the input field.Its return in form of Nodelist 
@@ -672,7 +672,7 @@ export class FieldsExtractorEngine {
     let inputField = element.querySelectorAll('input[type=text], input[type=date]')
     return { dom: inputField };
   }
-  getDom_date_time_without_year(element) {
+  getDomDateTimeWithoutYear(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DATE_WITHOUT_YEAR"
     // Return Type :Returns the input field.Its return in form of Nodelist 
@@ -680,60 +680,60 @@ export class FieldsExtractorEngine {
     let inputField = element.querySelectorAll('input[type=text], input[type=date]')
     return { dom: inputField };
   }
-  getDom_textNumeric(element) {
+  getDomTextNumeric(element) {
     // Input Type: DOM Object
-    // Extracts the Dom object from Question type ="TEXT_NUMERI"
+    // Extracts the Dom object from Question type ="TEXT_NUMERIC"
     // Return Type :Returns the input field.
     let inputField = element.querySelectorAll('input[type=text]')
     return { dom: inputField };
   }
-  getDom_texttel(element) {
+  getDomTextTel(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="TEXT_TEL"
     // Return Type :Returns the input field.
     let inputField = element.querySelectorAll('input[type=text]')
     return { dom: inputField };
   }
-  getDom_texturl(element) {
+  getDomTextUrl(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="TEXT_URL"
     // Return Type :Returns the input field.
     let inputField = element.querySelectorAll('input[type=url]')
     return { dom: inputField };
   }
-  getDom_date_time_with_meridiem(element) {
+  getDomDateTimeWithMeridiem(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DATE_TIME_WITH_MERIDIEM"
     // Return Type :Returns the input field as an array which contain two nodelists
     //- First nodelist- 0th index will has dom of Month , 1st index will contain Day, 2nd index-dom of year , 3rd index-dom of hour , 4th index-dom of minutes
     //- Second nodelist - 0th index will contain dom of `AM` and 1st index will contain dom of `PM` option
-    let inputField_datetime = element.querySelectorAll('input[type=text]')
+    let inputFieldDateTime = element.querySelectorAll('input[type=text]')
     let meridiem = element.querySelectorAll('div[role=option]')
-    let inputField = [inputField_datetime, meridiem]
+    let inputField = [inputFieldDateTime, meridiem]
     return { dom: inputField };
   }
-  getDom_time_with_meridiem(element) {
+  getDomTimeWithMeridiem(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="TIME_WITH_MERIDIEM"
     // Return Type :Returns the input field as an array of 2 NodeLists 
     //- First nodelist- 0th index will has dom of hour , 1st index will contain minutes , 3rd index-dom of seconds
     //- Second nodelist - 0th index will contain dom of `AM` and 1st index will contain dom of `PM` option
-    let inputField_time = element.querySelectorAll('input[type=text]')
+    let inputFieldTime = element.querySelectorAll('input[type=text]')
     let meridiem = element.querySelectorAll('div[role=option]')
-    let inputField = [inputField_time, meridiem]
+    let inputField = [inputFieldTime, meridiem]
     return { dom: inputField };
   }
-  getDom_date_time_with_meridiem_withoutyear(element) {
+  getDomDateTimeWithMeridiemWithoutYear(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DATE_TIME_WITH_MERIDIEM_WITHOUT_YEAR"
     //- First nodelist- 0th index will has dom of Month , 1st index will contain Day, 3rd index-dom of hour , 4th index-dom of minutes
     //- Second nodelist - 0th index will contain dom of `AM` and 1st index will contain dom of `PM` option
-    let inputField_datetime = element.querySelectorAll('input[type=text]')
+    let inputFieldDateTime = element.querySelectorAll('input[type=text]')
     let meridiem = element.querySelectorAll('div[role=option]')
-    let inputField = [inputField_datetime, meridiem]
+    let inputField = [inputFieldDateTime, meridiem]
     return { dom: inputField };
   }
-  getDom_time(element) {
+  getDomTime(element) {
     // Input Type: DOM Object
     // Extracts the Dom object from Question type ="DATE_TIME_WITH_MERIDIEM_WITHOUT_YEAR"
     // Return Type :Returns the input field.

--- a/src/filler/engines/fields-extractor-engine.js
+++ b/src/filler/engines/fields-extractor-engine.js
@@ -84,9 +84,70 @@ export class FieldsExtractorEngine {
         //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
         return this.getOptions_MULTIPLECHOICEGRID(element);
 
-        // Extracting the options if the field type is Dropdown
+      // Extracting the options if the field type is Dropdown
       case QType.DROPDOWN:
         return this.getOptions_Dropdown(element);
+
+      // Extracting the options if the field type is 'Text'.
+      case QType.TEXT:
+        //
+        return this.getDom_TEXT(element);
+
+      // Extracting the options if the field type is 'Paragraph'.
+      case QType.PARAGRAPH:
+        return this.getDom_paragraph(element);
+
+      // Extracting the options if the field type is 'Email'.
+      case QType.TEXT_EMAIL:
+        return this.getDom_email(element);
+
+      // Extracting the options if the field type is 'Text Numeric'.
+      case QType.TEXT_NUMERIC:
+        return this.getDom_TEXT(element);
+
+      // Extracting the options if the field type is 'Text Telephonic'.
+      case QType.TEXT_TEL:
+        return this.getDom_texttel(element);
+
+      // Extracting the options if the field type is 'Text URL'.
+      case QType.TEXT_URL:
+        return this.getDom_texturl(element);
+
+      // Extracting the options if the field type is 'Date'.
+      case QType.DATE:
+        return this.getDom_date(element);
+
+      // Extracting the options if the field type is 'Date And Time'.
+      case QType.DATE_AND_TIME:
+        return this.getDom_dateandtime(element);
+
+      // Extracting the options if the field type is 'Time'.
+      case QType.TIME:
+        return this.getDom_time(element);
+
+      // Extracting the options if the field type is 'Duration'.
+      case QType.DURATION:
+        return this.getDom_duration(element);
+
+      // Extracting the options if the field type is 'Date without Year'.
+      case QType.DATE_WITHOUT_YEAR:
+        return this.getDom_date_without_year(element);
+
+      // Extracting the options if the field type is 'Date without Year with Time'.
+      case QType.DATE_TIME_WITHOUT_YEAR:
+        return this.getDom_date_time_without_year(element);
+
+      // Extracting the options if the field type is 'Date with Time and Meridiem'.
+      case QType.DATE_TIME_WITH_MERIDIEM:
+        return this.getDom_date_time_with_meridiem(element);
+
+      // Extracting the options if the field type is 'Time and Meridiem'.
+      case QType.TIME_WITH_MERIDIEM:
+        return this.getDom_time_with_meridiem(element);
+
+      // Extracting the options if the field type is 'Date without Year with Time and Meridiem'.
+      case QType.DATE_TIME_WITH_MERIDIEM_WITHOUT_YEAR:
+        return this.getDom_date_time_with_meridiem_withoutyear(element);
     }
   }
 
@@ -388,7 +449,7 @@ export class FieldsExtractorEngine {
     }
 
     // Storing LowerBound and UpperBound data
-    const lowerUpperBound = {lowerBound, upperBound};
+    const lowerUpperBound = { lowerBound, upperBound };
 
     // Filter out any null or empty string elements from the array.
     // const filterLowerUpper = lowerUpperBound.filter(item => item !== null && item !== '');
@@ -552,5 +613,131 @@ export class FieldsExtractorEngine {
       }
     }
     return { options: options };
+  }
+
+  getDom_TEXT(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="TEXT"
+    // Return Type :Returns the input field.
+    let inputField = element.querySelectorAll('input[type=text]')
+    return { dom: inputField };
+  }
+
+  getDom_email(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="TEXT_EMAIL"
+    // Return Type :Returns the input field.
+
+    let inputField = element.querySelectorAll('input[type=text], input[type=email]')
+    return { dom: inputField };
+  }
+  getDom_paragraph(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="PARAGRAPH"
+    // Return Type :Returns the input field.
+
+    let inputField = element.querySelectorAll('textarea')
+    return { dom: inputField };
+  }
+  getDom_date(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DATE"
+    // Return Type :Returns the input field.Its returns input field as a Nodelist
+    //Its 0th index give Month_field , 1st index give Day_field , 2nd index has Year_field
+    let inputField = element.querySelectorAll('input[type=text], input[type=date]')
+    return { dom: inputField };
+  }
+  getDom_dateandtime(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DATE_AND_TIME"
+    // Return Type :Returns the input field.Its return in form of a Nodelist
+    //Its 0th index give Month_field , 1st index give Day_field , 2nd index has Year_field , 3rd index give Hour_field , 4th index give Minute_field
+
+    let inputField = element.querySelectorAll('input[type=text], input[type=date]')
+    return { dom: inputField };
+  }
+  getDom_duration(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DURATION"
+    // Return Type :Returns the input field.Its return in form of Nodelist 
+    //Its 0th index give Hour_field , 1st index give Minute_field , 2nd index has Seconds field
+    let inputField = element.querySelectorAll('input[type=text]')
+    return { dom: inputField };
+  }
+  getDom_date_without_year(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DATE_WITHOUT_YEAR"
+    // Return Type :Returns the input field.Its return in form of Nodelist 
+    //Its 0th index give month_field , 1st index give Day_field
+    let inputField = element.querySelectorAll('input[type=text], input[type=date]')
+    return { dom: inputField };
+  }
+  getDom_date_time_without_year(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DATE_WITHOUT_YEAR"
+    // Return Type :Returns the input field.Its return in form of Nodelist 
+    //Its 0th index give Month_field , 1st index give Day_field , 2nd index give Hour_field , 3rd index give Minute_field
+    let inputField = element.querySelectorAll('input[type=text], input[type=date]')
+    return { dom: inputField };
+  }
+  getDom_textNumeric(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="TEXT_NUMERI"
+    // Return Type :Returns the input field.
+    let inputField = element.querySelectorAll('input[type=text]')
+    return { dom: inputField };
+  }
+  getDom_texttel(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="TEXT_TEL"
+    // Return Type :Returns the input field.
+    let inputField = element.querySelectorAll('input[type=text]')
+    return { dom: inputField };
+  }
+  getDom_texturl(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="TEXT_URL"
+    // Return Type :Returns the input field.
+    let inputField = element.querySelectorAll('input[type=url]')
+    return { dom: inputField };
+  }
+  getDom_date_time_with_meridiem(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DATE_TIME_WITH_MERIDIEM"
+    // Return Type :Returns the input field as an array which contain two nodelists
+    //- First nodelist- 0th index will has dom of Month , 1st index will contain Day, 2nd index-dom of year , 3rd index-dom of hour , 4th index-dom of minutes
+    //- Second nodelist - 0th index will contain dom of `AM` and 1st index will contain dom of `PM` option
+    let inputField_datetime = element.querySelectorAll('input[type=text]')
+    let meridiem = element.querySelectorAll('div[role=option]')
+    let inputField = [inputField_datetime, meridiem]
+    return { dom: inputField };
+  }
+  getDom_time_with_meridiem(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="TIME_WITH_MERIDIEM"
+    // Return Type :Returns the input field as an array of 2 NodeLists 
+    //- First nodelist- 0th index will has dom of hour , 1st index will contain minutes , 3rd index-dom of seconds
+    //- Second nodelist - 0th index will contain dom of `AM` and 1st index will contain dom of `PM` option
+    let inputField_time = element.querySelectorAll('input[type=text]')
+    let meridiem = element.querySelectorAll('div[role=option]')
+    let inputField = [inputField_time, meridiem]
+    return { dom: inputField };
+  }
+  getDom_date_time_with_meridiem_withoutyear(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DATE_TIME_WITH_MERIDIEM_WITHOUT_YEAR"
+    //- First nodelist- 0th index will has dom of Month , 1st index will contain Day, 3rd index-dom of hour , 4th index-dom of minutes
+    //- Second nodelist - 0th index will contain dom of `AM` and 1st index will contain dom of `PM` option
+    let inputField_datetime = element.querySelectorAll('input[type=text]')
+    let meridiem = element.querySelectorAll('div[role=option]')
+    let inputField = [inputField_datetime, meridiem]
+    return { dom: inputField };
+  }
+  getDom_time(element) {
+    // Input Type: DOM Object
+    // Extracts the Dom object from Question type ="DATE_TIME_WITH_MERIDIEM_WITHOUT_YEAR"
+    // Return Type :Returns the input field.
+    let inputField = element.querySelectorAll('input[type=text]')
+    return { dom: inputField };
   }
 }

--- a/src/filler/engines/fields-extractor-engine.js
+++ b/src/filler/engines/fields-extractor-engine.js
@@ -8,92 +8,87 @@ export class FieldsExtractorEngine {
   constructor() { }
 
   getFields(element, fieldType) {
-
     let fields = {
-      "title": this.getTitle(element),
-      "description": this.getDescription(element)
+      title: this.getTitle(element),
+      description: this.getDescription(element),
     };
 
     // Dynamic values like options can be appended based on field type
     // Get options based on the field type and append them to the 'fields' object
 
+    // this sets the required fields itself, the conditional checking is done in the function itself
+    // the function is is highly abstracted
 
-    // Extracting the options if the field type is MultiCorrect
-    if (fieldType === QType.MULTI_CORRECT) {
-      //Handles `MultiCorrect`
-      //We get Options in an array
-      fields.options = this.getOptions_MULTI_CORRECT(element);
-    }
+    // TODO : the getOptions() can be broken down into further functions if needed, just ensure that the return type is consistent so that the below line still works
+    let optionFields = this.getOptions(fieldType, element);
+    fields = { ...fields, ...optionFields };
 
-
-    // Extracting the options if the field type is MultiCorrect_WITH_OTHER
-    else if (fieldType === QType.MULTI_CORRECT_WITH_OTHER) {
-      //Handles - `MultiCorrect With Other`.
-      // We get options in the form of an OBJECT which has two properties
-      //1. options - which contain options array
-      //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
-      fields.options = this.getOptions_MULTI_CORRECT_WITH_OTHER(element).options;
-      fields.other = this.getOptions_MULTI_CORRECT_WITH_OTHER(element).other_option;
-    }
-
-
-    // Extracting the options if the field type is Dropdown
-    else if (fieldType === QType.DROPDOWN) {
-      // We get options in the form of an array
-      fields.options = this.getOptions_Dropdown(element);
-    }
-
-
-    // Extracting the options if the field type is 'Multiple Choice'
-    else if (fieldType === QType.MULTIPLE_CHOICE) {
-      // We get options in the form of an array
-      fields.options = this.getOptions_MULTIPLE_CHOICE(element);
-
-    }
-
-
-    // Extracting the options if the field type is 'Multiple Choice With Other'.
-    if (fieldType === QType.MULTIPLE_CHOICE_WITH_OTHER) {
-      const optionsData = this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element);
-      fields.options = optionsData.options;
-      fields.other = optionsData.other_dom;
-    }
-
-    // Extracting the options if the field type is 'Linear Scale'
-    if (fieldType === QType.LINEAR_SCALE) {
-      //We get options in an object {filteredOptions,filterLowerUpper}
-      //In Linear_Scale Left and Right Bounds are given and options are distributed uniformly between these bounds.
-      //These elements which we are saying Upper_bound and Lower_bound may be strings or characters.
-
-      /*
-      Note
-      We added one more attribute to fields `lowerUpperBounds` whose value will have an array containing LowerBound,UpperBound.
-      */
-      fields.options = this.getOptions_LINEAR_SCALE(element).options;
-      fields.lowerUpperBounds = this.getOptions_LINEAR_SCALE(element).bounds;
-    }
-
-
-    // Extracting the options if the field type is `Multiple Choice Grid`
-    if (fieldType === QType.MULTIPLE_CHOICE_GRID) {
-      //We get options in form of an object
-      //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
-      fields.options = this.getOptions_MULTIPLECHOICEGRID(element);
-    }
-    //Returning the object fields.It contains title , description , options (if that question has) keys .
-
-
-    // Extracting the options if the field type is `Checkbox Grid` or `Multiple Choice Grid`
-    if (fieldType === QType.CHECKBOX_GRID) {
-      //We get options in form of an object
-      //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
-      fields.options = this.getOptions_CHECKBOXGRID(element);
-    }
-    //Returning the object fields.It contains title , description , options (if that question has) keys .
     return fields;
   }
 
+  getOptions(questionType, element) {
+    // Function for Extracting Options
+    // Input Type: DOM Object
+    // Extracts the options of the question
+    // ! Return Type : An object containing the options field and its required value
+    // ! the return object may contain field other than options, as returned by the corresponding QuestionType
 
+    switch (questionType) {
+
+      // Extracting the options if the field type is MultiCorrect
+      case QType.MULTI_CORRECT:
+        return this.getOptions_MULTI_CORRECT(element);
+
+      // Extracting the options if the field type is MultiCorrect_WITH_OTHER
+
+      case QType.MULTI_CORRECT_WITH_OTHER:
+        // We get options in the form of an OBJECT which has two properties
+        //1. options - which contain options array
+        //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+
+        return this.getOptions_MULTI_CORRECT_WITH_OTHER(element);
+
+      // Extracting the options if the field type is 'Multiple Choice'
+
+      case QType.MULTIPLE_CHOICE:
+        return this.getOptions_MULTIPLE_CHOICE(element);
+
+      // Extracting the options if the field type is 'Multiple Choice With Other'.
+
+      case QType.MULTIPLE_CHOICE_WITH_OTHER:
+        // We get options in the form of an OBJECT which has two properties
+        //1. options - which contain options array
+        //2. other - which contain `other:` which need to deal in separate way to ask Chatbot
+
+        return this.getOptions_MULTIPLE_CHOICE_WITH_OTHER(element);
+
+      // Extracting the options if the field type is 'Linear Scale'
+
+      case QType.LINEAR_SCALE:
+        //We get options in an object {filteredOptions,filterLowerUpper}
+        //In Linear_Scale Left and Right Bounds are given and options are distributed uniformly between these bounds.
+        //These elements which we are saying Upper_bound and Lower_bound may be strings or characters.
+
+        /*
+        Note
+        We added one more attribute to fields `lowerUpperBounds` whose value will have an array containing LowerBound,UpperBound.
+        */
+        return this.getOptions_LINEAR_SCALE(element);
+
+      // Extracting the options if the field type is `Checkbox Grid` or `Multiple Choice Grid`
+      case QType.CHECKBOX_GRID:
+        return this.getOptions_CHECKBOXGRID(element);
+
+      case QType.MULTIPLE_CHOICE_GRID:
+        //We get options in form of an object
+        //This object will contain 2 arrays 'rowsArray' and `columnsArray` which contains `row values` and `column values` respectively
+        return this.getOptions_MULTIPLECHOICEGRID(element);
+
+        // Extracting the options if the field type is Dropdown
+      case QType.DROPDOWN:
+        return this.getOptions_Dropdown(element);
+    }
+  }
 
   // Testing on Different Forms required
   getTitle(element) {
@@ -108,11 +103,10 @@ export class FieldsExtractorEngine {
     let content = "";
 
     // Every new line is either inside a div or independent, hence has nodeName #text
-    Array.from(required.childNodes).forEach(element => {
-      if (element.nodeName === '#text') {
+    Array.from(required.childNodes).forEach((element) => {
+      if (element.nodeName === "#text") {
         content += element.textContent + "\n";
-      }
-      else {
+      } else {
         content += element.textContent + "\n";
       }
     });
@@ -120,8 +114,6 @@ export class FieldsExtractorEngine {
     // Remove trailing whitespace at the end
     return content.trimEnd();
   }
-
-
 
   // Testing on Different Forms required
   getDescription(element) {
@@ -140,11 +132,10 @@ export class FieldsExtractorEngine {
     let content = "";
 
     // Every new line is either inside a div or independent, hence has nodeName #text
-    Array.from(required.childNodes).forEach(element => {
-      if (element.nodeName === '#text') {
+    Array.from(required.childNodes).forEach((element) => {
+      if (element.nodeName === "#text") {
         content += element.textContent + "\n";
-      }
-      else {
+      } else {
         content += element.textContent + "\n";
       }
     });
@@ -153,22 +144,19 @@ export class FieldsExtractorEngine {
     return content.trimEnd();
   }
 
-
-
-
-  // Functions for Extracting Options data and DOM of options.
-  //Extracting the options for field type = MultiCorrect
+  // Functions for Extracting Options
+  //Extracting the options for field type = MultiCorrect With Other or MultiCorrect
   getOptions_MULTI_CORRECT(element) {
     // Input Type: DOM Object
-    // Extracts the options data and option DOM of the question
+    // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
-    //         - For extracting options data - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
-    // Return Type : Array of objects having keys option_data and option_dom for all options.
+    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+    // Return Type : Array (containing option's data) =>null if no options are present
 
     const optionLabels = element.querySelectorAll('span[dir="auto"]');
     if (!optionLabels || optionLabels.length === 0) {
       // If no option labels are found, return an empty array
-      return [];
+      return { options: [] };
     }
 
     //Extracting divs which has radio buttons.
@@ -194,24 +182,24 @@ export class FieldsExtractorEngine {
       }
     }
 
-    return options;
+    return { options: options };
   }
 
 
   getOptions_MULTI_CORRECT_WITH_OTHER(element) {
     // Input Type: DOM Object
-    // Extracts the options data and option DOM of the question
+    // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
     //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
     // Return Type : OBJECT which has two properties
-    //1. options - itself an object containing {optiondata , optiondom} for every option.
-    //2. other - which contain `other:` and its dom object.
+    //1. options - which contain options array
+    //2. other - which contain `other:` which need to deal in separate way to ask Chatbot 
     //it will contain an input field and in case no option match , we need to write our answer there
 
     const optionLabels = element.querySelectorAll('span[dir="auto"]');
     if (!optionLabels || optionLabels.length === 0) {
       // If no option labels are found, return an empty array
-      return [];
+      return { options: [] };
     }
 
     //Extracting divs which has role=checkbox.
@@ -238,27 +226,29 @@ export class FieldsExtractorEngine {
     const other_option = []
     if (clickElements.length > 0 && clickElements.length === optiondata.length + 1) {
       for (let i = 0; i < clickElements.length - 1; i++) {
-        options.push({ option_data: optiondata[i], option_dom: clickElements[i], });
+        options.push({ data: optiondata[i], dom: clickElements[i], });
       }
       const input_in_mcwo = element.querySelector('input[dir="auto"]');
-      other_option.push({ option_data: otherOption, option_dom: clickElements[clickElements.length - 1], inputBoxDom: input_in_mcwo });
+      other_option.push({ data: otherOption, dom: clickElements[clickElements.length - 1], inputBoxDom: input_in_mcwo });
     }
-    return { options, other_option };
+
+    return { options: options, other: other_option };
+
   }
 
 
-  //Extracting the options for field type = MultipleChoice
+  //Extracting the options for field type = MultipleChoice With Other or MultipleChoice
   getOptions_MULTIPLE_CHOICE(element) {
     // Input Type: DOM Object
-    // Extracts the option_data of the question and their corresponding dom
+    // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is obtained by selecting the divs which has role="radio"
-    // Return Type : An array of objects having keys - option_data , option_dom
+    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+    // Return Type : Array (containing option's data) =>null if no options are present
 
     const optionLabels = element.querySelectorAll('span[dir="auto"]');
     if (!optionLabels || optionLabels.length === 0) {
       // If no option labels are found, return an empty array
-      return [];
+      return { options: [] };
     }
 
     //Extracting divs which has radio buttons.
@@ -285,24 +275,24 @@ export class FieldsExtractorEngine {
       }
     }
 
-    return options;
+    return { options: options };
   }
 
-  //Extracting the options for field type = MultipleChoice With Other
+
   getOptions_MULTIPLE_CHOICE_WITH_OTHER(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
-    //         - The required node is obtained by selecting the divs with dir="auto" and then going inside them.
-    // Return Type : OBJECT which has two properties options , other these 2 themselves are objects
-    //1. options - object contain option_data and option_dom
-    //2. other - which contain `other:` , other_dom , other_input
+    //         - The required node is obtained by selecting the span as options were inside them , also these span has dir="auto"
+    // Return Type : OBJECT which has two properties
+    //1. options - which contain options array
+    //2. other - which contain `other:` which need to deal in separate way to ask Chatbot 
     //it will contain an input field and in case no option match , we need to write our answer there
 
     const optionLabels = element.querySelectorAll('span[dir="auto"]');
     if (!optionLabels || optionLabels.length === 0) {
       // If no option labels are found, return an empty array
-      return [];
+      return { options: [] };
     }
 
     //Extracting divs which has radio buttons.
@@ -331,29 +321,33 @@ export class FieldsExtractorEngine {
     const other_dom = []
     if (clickElements.length > 0 && clickElements.length === optiondata.length + 1) {
       for (let i = 0; i < clickElements.length - 1; i++) {
-        options.push({ option_data: optiondata[i], option_dom: clickElements[i] });
+        options.push({ data: optiondata[i], dom: clickElements[i] });
       }
       const input_in_mcwo = element.querySelector('input[dir="auto"]');
 
       other_dom.push({ other_data: otherOption, other_dom: clickElements[clickElements.length - 1], inputBoxDom: input_in_mcwo });
     }
-    return { options, other_dom };
+
+    return { options: options, other: other_dom };
+
   }
 
 
   //Extracting the options for field type = LinearScale
   getOptions_LINEAR_SCALE(element) {
     // Input Type: DOM Object
-    // Extracts the options of the question and their corresponding dom
+    // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
     //         - The required node for Lower and Upper bound is obtained by selecting the span whose role="presentation" and then need to traverse more 
     //since no attribute can be found which can help
     //         -Option are present in in divs inside elements which has dir="auto".
-    // Return Type : Object containing two arrays { bounds:filterLowerUpper, options: optionsArray } , optionsArray is an array of objects which contain option_data and corresponding option_dom.
+    // Return Type : Object containing two arrays - {filterLowerUpper,filteredOptions}
     //filterLowerUpper- ArraySize=2 , contain lowerBound , upperBound
     //filteredOptions- It will contain options.
 
-    const elementsWithHierarchy = element.querySelector('span[role="presentation"]').querySelectorAll('div > div:last-child > div:last-child');
+    let elementsWithHierarchy = element
+      .querySelector('span[role="presentation"]')
+      .querySelectorAll("div > div:last-child > div:last-child");
     let lowerBound = null;
     let upperBound = null;
 
@@ -371,11 +365,11 @@ export class FieldsExtractorEngine {
     elementsWithHierarchy.forEach((el) => {
       const textContent = el.textContent.trim();
       if (lowerBound === null && textContent !== '') {
-        lowerBound = textContent;             //Assigning lowerBound with 1st node
+        lowerBound = textContent;  //Assigning lowerBound with 1st node
       }
 
       else if (lowerBound !== null && textContent !== '') {
-        upperBound = textContent;             //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound. 
+        upperBound = textContent;  //Assigning upperBound with each node we are at during traversal so last node will be assigned to upperBound. 
       }
 
     });
@@ -389,34 +383,34 @@ export class FieldsExtractorEngine {
       let j = 0;
       for (let i = 0; i < options.length; i++) {
         if (options[i] != "")
-          optionsArray.push({ option_data: options[i], option_dom: domsArray[j++], });
+          optionsArray.push({ data: options[i], dom: domsArray[j++], });
       }
     }
 
     // Storing LowerBound and UpperBound data
-    const lowerUpperBound = [lowerBound, upperBound];
+    const lowerUpperBound = {lowerBound, upperBound};
 
     // Filter out any null or empty string elements from the array.
-    const filterLowerUpper = lowerUpperBound.filter(item => item !== null && item !== '');
+    // const filterLowerUpper = lowerUpperBound.filter(item => item !== null && item !== '');
 
-    return { bounds: filterLowerUpper, options: optionsArray };
+    return { bounds: lowerUpperBound, options: optionsArray };
   }
-
 
 
   //Extracting the options for field type = Multiple Choice Grid.
   getOptions_MULTIPLECHOICEGRID(element) {
     // Input Type: DOM Object
-    // Extracts the options of the question and their corresponding DOM objects
+    // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
     //         - The required node is founded by Brute-force traversing no attribute can be found to be helpful.
     //         
-    // Return Type : An array which contain 2 objects 
-
+    // Return Type : Object containing 2 array 
+    //               - 1st array will denote contents of row1,row2,row3...
+    //               - 2nd array will denote contents of column1,column2,column3
 
     //No property can be found so need to traverse this way only!
-    const path = "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
-
+    let path =
+      "div:first-child > div:first-child > div:nth-child(2) > div:first-child > div:nth-child(2) > div";
 
     //After getting to this path,
     //its first child contains a div which contains all columns.
@@ -427,12 +421,14 @@ export class FieldsExtractorEngine {
 
     const gridArray = [];
     //In these columns if we think in term of matrix then (0,0) place is left vacant so we sliced form 1 and take out content of each column.
-    const columnsArray = Array.from(columns).slice(1).map((column) => column.textContent.trim());
+    const columnsArray = Array.from(columns)
+      .slice(1)
+      .map((column) => column.textContent.trim());
     const rowsArray = Array.from(rows).map((row) => row.textContent.trim());
 
-    //Returning an Object containing 2 array 
+    //Returning an Object containing 2 array
     //      - 1st array will denote contents of row1,row2,row3...
-    //      -2nd array will denote contents of column1,column2,column3dis
+    //      -2nd array will denote contents of column1,column2,column3
     let optionsArray = []
     rows.forEach((row) => {
       const columns = row.querySelectorAll('div[role="radio"]');
@@ -444,7 +440,7 @@ export class FieldsExtractorEngine {
         rowColumns.push(targetDom);
       });
 
-      optionsArray.push(rowColumns);             //option array will contain those buttons which we mark.
+      optionsArray.push(rowColumns);  //option array will contain those buttons which we mark.
 
     });
 
@@ -463,15 +459,15 @@ export class FieldsExtractorEngine {
       for (let p = q; p < columnsArray.length * (i + 1); p++, q++) {
         arr.push(option_dom[p]);
       }
-      row_col_dom.push({ row: rowsArray[i], option_n_dom: arr })
+      row_col_dom.push({ row: rowsArray[i], cols: arr })
     }
+
     return {
-      row_col_dom
+      options: row_col_dom,
     };
   }
 
-
-  //Extracting the options for field type = Multiple Choice Grid or Checkbox Grid.
+  //Extracting the options for field type = Checkbox Grid.
   getOptions_CHECKBOXGRID(element) {
     // Input Type: DOM Object
     // Extracts the options of the question
@@ -524,10 +520,10 @@ export class FieldsExtractorEngine {
       for (let p = checkbox_number; p < columnsArray.length * ((row_index) + 1); p++, checkbox_number++) {
         arr.push(option_dom[p]);
       }
-      row_col_dom.push({ row: rowsArray[row_index], option_n_dom: arr })
+      row_col_dom.push({ row: rowsArray[row_index], cols: arr })
     }
     return {
-      row_col_dom
+      options: row_col_dom
     };
   }
 
@@ -538,13 +534,13 @@ export class FieldsExtractorEngine {
     // Extracts the options of the question
     // Tweak : - The extraction is based on the DOM tree
     //         - The required node is found by selecting all divs having role="option" , inside this there are spans which contain options.
-    // Return Type : Array containing objects {option_data: optionsWithoutChoose[i] , option_dom:optiondom[i]}
+    // Return Type : Array containing options.
 
     const optionDivs = element.querySelectorAll('div[role="option"]');
-
     if (!optionDivs || optionDivs.length === 0) {
-      return [];
+      return { options: [] };
     }
+
     let options = [];
     //starting loop from one as option at 0th index is `Choose` so removed that.
     for (let i = 1; i < optionDivs.length; i++) {
@@ -555,6 +551,6 @@ export class FieldsExtractorEngine {
         options.push({ option_data: span.textContent.trim(), option_dom: optionDiv });
       }
     }
-    return options;
+    return { options: options };
   }
 }


### PR DESCRIPTION
**This commit adds functionality to extract DOM objects and option data for all types of questions that have options.** 

The function now correctly retrieves the DOM elements and their corresponding option data for dropdowns , MultiCorrect , Checkboxes , MultiCorrect With Other , Multiple Choice , Multiple Choice With Other , Multiple Choice Grid , and Linear Scale. . 

The commit also includes improvements to handle cases where questions do not have any options, returning an empty array in such cases.