### PR TITLE
Validate response coming from CHAT GPT for various question types

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "concurrently": "^8.2.0",
+    "libphonenumber-js": "^1.10.39",
     "web-ext": "^7.6.2"
   }
 }

--- a/src/filler/engines/parser-engine.js
+++ b/src/filler/engines/parser-engine.js
@@ -1,29 +1,15 @@
 import QType from "../../utils/question-types";
+import { isValidPhoneNumber } from "libphonenumber-js";
+import DEFAULT_TEL_COUNTRY from "../../utils/environment";
 
 export class ParserEngine {
     constructor() { }
 
 
 
-    parse(fieldType, value, response) {
-
-        // It is hard-coded for testing purposes.
-        response = {
-            TEXT: "Amit",
-            EMAIL: "abc@gmail.com",
-            PARAGRAPH: "Please enjoy these great stories, fairy-tales, fables, and nursery rhymes for children.They help kids learn to read and make excellent bedtime stories! We have hundreds of great children's stories for you to share.",
-            TEXT_NUMERIC: "1234",
-            TEXT_TEL: "9111421028",
-            MULTI_CORRECT: ["Hiking", "Exploring"],
-            MULTI_CORRECT_WITH_OTHER: {
-                options: ["Day 3", "Day 1"],
-                other: "abcdefg"
-            }
-        }
-
-
+    parse(fieldType, extractedValue, response) {
         // Input Type : fieldType is a enum based on QType enum
-        //              value is variable membered object,
+        //              extractedValue is variable membered object,
         //              more information about it can be found in
         //              field-extractor engine docs 
         //              response is a string generated value as a response from prompt engine
@@ -31,69 +17,102 @@ export class ParserEngine {
         // from prompt-engine
         // Output Type : string containing the response if true or null if any expected inputs
 
-        value = this.validateResponse(value);
+        // It is hard-coded, only for testing purposes.
+        let testResponse = {
+            TEXT: "Amit",
+            EMAIL: "abc@gmail.com",
+            PARAGRAPH: "Please enjoy these great stories, fairy-tales, fables, and nursery rhymes for children.They help kids learn to read and make excellent bedtime stories! We have hundreds of great children's stories for you to share.",
+            TEXT_NUMERIC: "1234",
+            TEXT_TEL: "9111421028",
+            MULTI_CORRECT: "Hiking\nExploring",
+            MULTI_CORRECT_WITH_OTHER: "Day 1\nDay 2",
+            DATE: "22-12-2022",
+            TIME: "10-12",
+            DATE_AND_TIME: "22-12-2022-12-12"
+        }
 
 
-        if (fieldType != null && value != null) {
-            if (fieldType === QType.TEXT) {
-                return this.parseText(response.TEXT);
-            }
-            else if (fieldType === QType.TEXT_EMAIL) {
-                return this.parseEmail(response.EMAIL);
-            }
-            else if (fieldType === QType.MULTI_CORRECT_WITH_OTHER) {
-                return this.parseMultipleCorrectWithOther(value, response.MULTI_CORRECT_WITH_OTHER);
-            }
-            else if (fieldType === QType.MULTI_CORRECT) {
-                return this.parseMultiCorrect(value, response.MULTI_CORRECT);
-            }
-            else if (fieldType === QType.PARAGRAPH) {
-                return this.parseParagraph(response.PARAGRAPH);
-            }
-            else if (fieldType === QType.TEXT_NUMERIC) {
-                return this.parseTextNumberic(response.TEXT_NUMERIC);
-            }
-            else if (fieldType === QType.TEXT_TEL) {
-                return this.parseText_Tel(response.TEXT_TEL);
-            }
-            else if (fieldType === QType.DATE) {
-                return this.validateDate(response);
-            }
-            else if (fieldType === QType.DATE_AND_TIME) {
-                return this.validateDateAndTime(response);
-            }
-            else if (fieldType === QType.TIME) {
-                return this.validateTime(response);
-            }
-            else {
-                return null;
-            }
+
+        response = this.validateResponse(response);
+
+
+        if (fieldType != null && extractedValue != null) {
+            switch (fieldType) {
+                case QType.TEXT:
+                    return this.validateText(testResponse.TEXT);
+                case QType.TEXT_EMAIL:
+                    return this.validateEmail(testResponse.EMAIL);
+                case QType.MULTI_CORRECT_WITH_OTHER:
+                    return this.validateMultipleCorrectWithOther(extractedValue, testResponse.MULTI_CORRECT_WITH_OTHER);
+                case QType.MULTI_CORRECT:
+                    return this.validateMultiCorrect(extractedValue, testResponse.MULTI_CORRECT);
+                case QType.PARAGRAPH:
+                    return this.validateParagraph(testResponse.PARAGRAPH);
+                case QType.TEXT_NUMERIC:
+                    return this.validateTextNumeric(testResponse.TEXT_NUMERIC);
+                case QType.TEXT_TEL:
+                    return this.validateTextTel(testResponse.TEXT_TEL);
+                case QType.DATE:
+                    return this.validateDate(testResponse.DATE);
+                case QType.DATE_AND_TIME:
+                    return this.validateDateAndTime(testResponse.DATE_AND_TIME);
+                case QType.TIME:
+                    return this.validateTime(testResponse.TIME);
+                default:
+                    return null;
+            }            
         }
         else {
             return null;
         }
     }
 
-    parseText(response) {
+    validateText(response) {
         // Input Type : String [given by chatgpt]
         // Check if it's not text or not a/c:
         //          i) The response length is always greater than zero (0).
-        //          ii) The number of lines is less than or equal to one (1).
+        //          ii) The number of lines is equal to one (1).
         //          
         // Return Type : Boolean
 
         let text = response.trim();
-        let noOfLines = 1;
-        for (let i = 0; i < text.length; i++) {
-            if (text[i] == '\n') {
-                noOfLines++;
-            }
-        }
 
-        if (text.length >= 1 && noOfLines <= 1) {
-            return true;
-        }
-        return false;
+        return text.length > 0 && !text.includes('\n', '\r');
+    }
+
+    validateParagraph(response) {
+        // Input Type : String [given by chatgpt]
+        // Check if it's not Paragraph or not, a/c to:
+        //          i) The response length is always greater than zero (0).
+        //          ii) The number of lines is greater than or equal to one (1).
+        //          
+        // Return Type : Boolean
+
+        return response.trim().length > 0;
+
+    }
+
+    validateTextNumeric(response) {
+        // Input Type : String [given by chatgpt]
+        // Valid Input Format :- Numeric Values only
+        // Check if it's a valid Text Numeric or not, a/c to:
+        //          i) given input matches with an numberRegex or not.
+        //                
+        // Return Type : Boolean
+
+        return Number(response.trim()).valueOf() !== NaN;
+    }
+
+    validateTextTel(response) {
+        // Input Type : String [given by chatgpt]
+        // Check if it's a valid Phone-Number or not, a/c to:
+        //          i) given input matches with an PhoneRegex or not.
+        //                
+        // Return Type : Boolean
+
+        // let PhoneRegex = "^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$"
+        // Alternatively can use regex, if package size becomes an constraint
+        return isValidPhoneNumber(response, DEFAULT_TEL_COUNTRY);
     }
 
     validateEmail(response) {
@@ -112,7 +131,6 @@ export class ParserEngine {
         // Valid Input Format :- DD-MM--YYYY
         // Checks if date is in correct format or not
         // Output :- Boolean
-
         var dateValid = /^([0][1-9]|[1-2][0-9]|[3][0-1])-([0][1-9]|[1][0-2])-(\d{4})$/
         const dateArr = response === null ? false : response.match(dateValid)
         if (dateArr) {
@@ -156,7 +174,7 @@ export class ParserEngine {
         var dateTimeValid = /^([0][1-9]|[1-2][0-9]|[3][0-1])-([0][1-9]|[1][0-2])-(\d{4})-([01][0-9]|[2][0-3])-([0-5][0-9])$/
         const dateArr = response === null ? false : response.match(dateTimeValid)
         if (dateArr) {
-            
+
             // Months containing 31 days
             const valid31 = ['01', '03', '05', '07', '08', '10', '12']
             const date = dateArr[1]
@@ -197,120 +215,46 @@ export class ParserEngine {
     }
 
 
-    parseParagraph(response) {
-        //  Input Type : String [given by chatgpt]
-        // Check if it's not Paragraph or not a/c:
-        //          i) The response length is always greater than zero (0).
-        //          ii) The number of lines is greater than or equal to one (1).
-        //          
+
+    validateMultiCorrect(extractedValue, response) {
+        // Input Type : String [given by chatgpt] & extractedValue [DOM object]
+        // Valid Input Format :- Multi Lined Options, with each new option separated by a newline
+        // Check if it's Multi-correct's response are matches with actual options or not.
         // Return Type : Boolean
 
-        let Paragraph = response.trim();
-        let noOfLines = 1;
-        for (let i = 0; i < Paragraph.length; i++) {
-            if (Paragraph[i] == '\n') {
-                noOfLines++;
+        let flag = true; // Assuming response for Prompt engine is correct by default
+        let responseOptions = response.split(/\r?\n/);
+
+        let actualOptions = [];
+        extractedValue.options.forEach((option) => { actualOptions.push(option.data) });
+
+        for (let i = 0; i < responseOptions.length; i++) {
+            if (actualOptions.findIndex((option) => 
+                    responseOptions[i].toLowerCase() === option.toLowerCase()) === -1) {
+                        flag = false;
             }
         }
 
-        if (Paragraph.length >= 1 && noOfLines >= 1) {
-            return true;
-        }
-        return false;
+        console.log(actualOptions)
+        console.log(responseOptions)
+        console.log(flag)
 
-    }
-
-    parseTextNumberic(response) {
-
-        // Input Type : String [given by chatgpt]
-        // Check if it's a valid Text-Number or not a/c:
-        //          i) given input matches with an numberRegex or not.
-        //                
-        // Return Type : Boolean
-
-        let numberRegex = "^[0-9]*$"
-        if (response.match(numberRegex)) {
-            return true;
-        }
-        return false;
-    }
-
-
-    parseText_Tel(response) {
-
-        // Input Type : String [given by chatgpt]
-        // Check if it's a valid Phone-Number or not a/c:
-        //          i) given input matches with an PhoneRegex or not.
-        //                
-        // Return Type : Boolean
-
-        let PhoneRegex = "^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$"
-
-        if (response.match(PhoneRegex)) {
-            return true;
-        }
-        return false;
-    }
-
-    parseMultiCorrect(value, response) {
-        //  Input Type : String [given by chatgpt] & value [DOM object]
-        // Check if it's Multi-correct_response are match with DOM-options or not.
-        // Return Type : Boolean
-
-        let flag = false;
-        let array = [];
-        for (let i = 0; i < response.length; i++) {
-            for (let j = 0; j < value.options.length; j++) {
-                if (value.options[j].toUpperCase() === response[i].toUpperCase()) {
-                    array.push("true");
-                }
-            }
-        }
-        if (array.length === response.length) {
-            flag = true;
-        }
-        else {
-            flag = false;
-        }
         return flag;
     }
 
 
-    parseMultipleCorrectWithOther(value, response) {
-
-        //  Input Type : String [given by chatgpt] & value [DOM object]
-        // Check if it's Multi-correct-withOther_response are match with value(DOM) a/c :
+    validateMultipleCorrectWithOther(extractedValue, response) {
+        // Input Type : String [given by chatgpt] & extractedValue [DOM object]
+        // Valid Input Format :- Multi Lined Options, with each new option separated by a newline, 
+        //                       in case of non-matching options, response should be like `Other <Text>` format
+        // Check if it's Multi-correct withOther's response are match with extractedValue(DOM) a/c to :
         //             i) Check if the given response options match the options in the DOM
         //             ii) If the response options do not match,check if the "response-other"
-        //                 option matches any of the Text or Paragraph or not.
+        //                 option matches any of the Text or not.
+        //             iii) We assume other option flag is invoked when all other option is incorrect
         // Return Type : Boolean
 
-        let Optionsflag = false, otherflg = false;
-        let array = [];
-        for (let i = 0; i < response.options.length; i++) {
-            for (let j = 0; j < value.options.length; j++) {
-                if (value.options[j].toUpperCase() === response.options[i].toUpperCase()) {
-                    array.push("true");
-                }
-            }
-        }
-
-        if (array.length === response.options.length) {
-            Optionsflag = true;
-        }
-        else {
-            Optionsflag = false;
-        }
-        otherflg = this.parseParagraph(response.other);
-        if (Optionsflag === true) {
-            return true;
-        }
-        else {
-            if (otherflg === true) {
-                return true;
-            }
-        }
-        return false;
+        return this.validateMultiCorrect(extractedValue, response) || ( response.startsWith("Other") && this.validateText(response));
     }
 
     validateResponse(response) {

--- a/src/filler/engines/parser-engine.js
+++ b/src/filler/engines/parser-engine.js
@@ -3,7 +3,25 @@ import QType from "../../utils/question-types";
 export class ParserEngine {
     constructor() { }
 
+
+
     parse(fieldType, value, response) {
+
+        // It is hard-coded for testing purposes.
+        response = {
+            TEXT: "Amit",
+            EMAIL: "abc@gmail.com",
+            PARAGRAPH: "Please enjoy these great stories, fairy-tales, fables, and nursery rhymes for children.They help kids learn to read and make excellent bedtime stories! We have hundreds of great children's stories for you to share.",
+            TEXT_NUMERIC: "1234",
+            TEXT_TEL: "9111421028",
+            MULTI_CORRECT: ["Hiking", "Exploring"],
+            MULTI_CORRECT_WITH_OTHER: {
+                options: ["Day 3", "Day 1"],
+                other: "abcdefg"
+            }
+        }
+
+
         // Input Type : fieldType is a enum based on QType enum
         //              value is variable membered object,
         //              more information about it can be found in
@@ -15,15 +33,28 @@ export class ParserEngine {
 
         value = this.validateResponse(value);
 
+
         if (fieldType != null && value != null) {
             if (fieldType === QType.TEXT) {
-                return this.parseText(response);
+                return this.parseText(response.TEXT);
             }
             else if (fieldType === QType.TEXT_EMAIL) {
-                return this.validateEmail(response);
+                return this.parseEmail(response.EMAIL);
             }
-            else if (fieldType === QType.MULTIPLE_CHOICE) {
-                return this.parseMultipleChoice(value, response);
+            else if (fieldType === QType.MULTI_CORRECT_WITH_OTHER) {
+                return this.parseMultipleCorrectWithOther(value, response.MULTI_CORRECT_WITH_OTHER);
+            }
+            else if (fieldType === QType.MULTI_CORRECT) {
+                return this.parseMultiCorrect(value, response.MULTI_CORRECT);
+            }
+            else if (fieldType === QType.PARAGRAPH) {
+                return this.parseParagraph(response.PARAGRAPH);
+            }
+            else if (fieldType === QType.TEXT_NUMERIC) {
+                return this.parseTextNumberic(response.TEXT_NUMERIC);
+            }
+            else if (fieldType === QType.TEXT_TEL) {
+                return this.parseText_Tel(response.TEXT_TEL);
             }
             else if (fieldType === QType.DATE) {
                 return this.validateDate(response);
@@ -44,9 +75,25 @@ export class ParserEngine {
     }
 
     parseText(response) {
-        // TODO
-        // Check If it's not multiline or not etc
-        return response;
+        // Input Type : String [given by chatgpt]
+        // Check if it's not text or not a/c:
+        //          i) The response length is always greater than zero (0).
+        //          ii) The number of lines is less than or equal to one (1).
+        //          
+        // Return Type : Boolean
+
+        let text = response.trim();
+        let noOfLines = 1;
+        for (let i = 0; i < text.length; i++) {
+            if (text[i] == '\n') {
+                noOfLines++;
+            }
+        }
+
+        if (text.length >= 1 && noOfLines <= 1) {
+            return true;
+        }
+        return false;
     }
 
     validateEmail(response) {
@@ -149,10 +196,121 @@ export class ParserEngine {
         return response && Boolean(response.match(timeValid));
     }
 
-    parseMultipleChoice(value, response) {
-        // TODO
 
-        return response;
+    parseParagraph(response) {
+        //  Input Type : String [given by chatgpt]
+        // Check if it's not Paragraph or not a/c:
+        //          i) The response length is always greater than zero (0).
+        //          ii) The number of lines is greater than or equal to one (1).
+        //          
+        // Return Type : Boolean
+
+        let Paragraph = response.trim();
+        let noOfLines = 1;
+        for (let i = 0; i < Paragraph.length; i++) {
+            if (Paragraph[i] == '\n') {
+                noOfLines++;
+            }
+        }
+
+        if (Paragraph.length >= 1 && noOfLines >= 1) {
+            return true;
+        }
+        return false;
+
+    }
+
+    parseTextNumberic(response) {
+
+        // Input Type : String [given by chatgpt]
+        // Check if it's a valid Text-Number or not a/c:
+        //          i) given input matches with an numberRegex or not.
+        //                
+        // Return Type : Boolean
+
+        let numberRegex = "^[0-9]*$"
+        if (response.match(numberRegex)) {
+            return true;
+        }
+        return false;
+    }
+
+
+    parseText_Tel(response) {
+
+        // Input Type : String [given by chatgpt]
+        // Check if it's a valid Phone-Number or not a/c:
+        //          i) given input matches with an PhoneRegex or not.
+        //                
+        // Return Type : Boolean
+
+        let PhoneRegex = "^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$"
+
+        if (response.match(PhoneRegex)) {
+            return true;
+        }
+        return false;
+    }
+
+    parseMultiCorrect(value, response) {
+        //  Input Type : String [given by chatgpt] & value [DOM object]
+        // Check if it's Multi-correct_response are match with DOM-options or not.
+        // Return Type : Boolean
+
+        let flag = false;
+        let array = [];
+        for (let i = 0; i < response.length; i++) {
+            for (let j = 0; j < value.options.length; j++) {
+                if (value.options[j].toUpperCase() === response[i].toUpperCase()) {
+                    array.push("true");
+                }
+            }
+        }
+        if (array.length === response.length) {
+            flag = true;
+        }
+        else {
+            flag = false;
+        }
+        return flag;
+    }
+
+
+    parseMultipleCorrectWithOther(value, response) {
+
+        //  Input Type : String [given by chatgpt] & value [DOM object]
+        // Check if it's Multi-correct-withOther_response are match with value(DOM) a/c :
+        //             i) Check if the given response options match the options in the DOM
+        //             ii) If the response options do not match,check if the "response-other"
+        //                 option matches any of the Text or Paragraph or not.
+        // Return Type : Boolean
+
+        let Optionsflag = false, otherflg = false;
+        let array = [];
+        for (let i = 0; i < response.options.length; i++) {
+            for (let j = 0; j < value.options.length; j++) {
+                if (value.options[j].toUpperCase() === response.options[i].toUpperCase()) {
+                    array.push("true");
+                }
+            }
+        }
+
+        if (array.length === response.options.length) {
+            Optionsflag = true;
+        }
+        else {
+            Optionsflag = false;
+        }
+        otherflg = this.parseParagraph(response.other);
+        if (Optionsflag === true) {
+            return true;
+        }
+        else {
+            if (otherflg === true) {
+                return true;
+            }
+        }
+        return false;
     }
 
     validateResponse(response) {
@@ -161,6 +319,5 @@ export class ParserEngine {
         // Check if it not one of those invalid CHATGPT or any other engine failed messages
         return response;
     }
-
 
 }

--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -1,0 +1,2 @@
+const DEFAULT_TEL_COUNTRY = "IN";
+export default DEFAULT_TEL_COUNTRY;

--- a/src/utils/gpt-engines.js
+++ b/src/utils/gpt-engines.js
@@ -1,8 +1,7 @@
 // import and use this ENUM for referring to question types, as it will be more convenient throughout the code rather than hardcoding the string values for each type
 const GPTEngine = {
-    CHATGPT: "gpt-turbo-3.5",
-    BARD: "palm",
-  };
-  
-  export default GPTEngine;
-  
+  CHATGPT: "gpt-turbo-3.5",
+  BARD: "palm",
+};
+
+export default GPTEngine;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,6 +2289,11 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+libphonenumber-js@^1.10.39:
+  version "1.10.39"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.39.tgz#12dd512621c9ebb13402a694ac81dc78511cd982"
+  integrity sha512-iPMM/NbSNIrdwbr94rAOos6krB7snhfzEptmk/DJUtTPs+P9gOhZ1YXVPcRgjpp3jJByclfm/Igvz45spfJK7g==
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"


### PR DESCRIPTION
This pull request aims to enhance the CHAT GPT's response validation capabilities for different question types, ensuring accurate and reliable validations for Text, Email, Paragraph, Text_Numbric, Tex_Tel, Multi_Correct, and Multi_Correct_WITH_OTHER question types.
 By implementing these validations, we can significantly improve the user experience and provide more accurate responses to various input formats.